### PR TITLE
GitHub OAuth + in-app job status

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ This repo contains:
    - `prompts/30_star_stories.md`
    - `prompts/40_self_eval_sections.md`
 
+## How to get the data to paste
+
+**Quick path:** [docs/how-to-get-evidence.md](docs/how-to-get-evidence.md) — create a GitHub token, run collect + normalize, then paste or upload **evidence.json** on the Generate page.
+
 ## Scripts
+
 - **Collect (on-demand):** `GITHUB_TOKEN=xxx yarn collect --start YYYY-MM-DD --end YYYY-MM-DD --output raw.json` — fetches your PRs and reviews from GitHub for the date range. No cron required; run when you want fresh data.
 - **Normalize:** `yarn normalize --input raw.json --output evidence.json` — turns raw API output into the evidence contract.
-- **Generate:** `yarn generate evidence.json` — runs the LLM pipeline (themes → bullets → STAR → self-eval). Requires `OPENAI_API_KEY`.
+- **Generate:** `yarn generate evidence.json` — runs the LLM pipeline (themes → bullets → STAR → self-eval). Writes to `./out` by default; use `--out dir` to override. Requires `OPENAI_API_KEY`.
 
 See `docs/data-collection.md` for on-demand vs optional periodic (cron) refresh. For future Slack/Jira and other sources, see `docs/multi-source-plan.md`.
 

--- a/docs/how-to-get-evidence.md
+++ b/docs/how-to-get-evidence.md
@@ -1,0 +1,88 @@
+# How to get the GitHub data to paste (dummy-proof)
+
+The app needs one file: **evidence.json**. Not raw.json. Not a screenshot. Not the token. The file named **evidence.json** that you create in Step 2 below.
+
+---
+
+## Easiest: Sign in with GitHub (in the app)
+
+1. Open the app and go to the **Generate** page.
+2. Click **“Connect (public repos only)”** or **“Connect (include private repos)”** to sign in with GitHub.
+3. Choose your date range and click **“Fetch my data”**. The app fetches your PRs and reviews in the background; when it’s done, the evidence JSON will appear in the text area.
+4. Click **“Generate review”**.
+
+Your token is never stored; we only use it during the session. You can also use a Personal Access Token or the CLI (below) if you prefer.
+
+---
+
+## Step 1: Get a GitHub token (for CLI or paste-in-app)
+
+1. Click this link: **https://github.com/settings/tokens**
+2. Click **“Tokens (classic)”** in the left sidebar (not “Fine-grained tokens”).
+3. Click the green **“Generate new token”** → **“Generate new token (classic)”**.
+4. **Note:** type anything (e.g. `AnnualReview`). **Expiration:** pick what you want.
+5. **Scopes:** tick the box for **`repo`** (that will tick all 4 repo sub-boxes). If you only use public repos you can tick only **`public_repo`**.
+6. Scroll down, click **“Generate token”**.
+7. **Copy the token immediately.** It looks like `ghp_xxxxxxxxxxxxxxxxxxxx`. You cannot see it again after you leave the page.
+8. Paste it somewhere safe for the next step (e.g. a temporary file or password manager). **Do not commit it or share it.**
+
+---
+
+## Step 2: Create evidence.json on your machine
+
+Do this in a terminal, in the **root folder of this repo** (the folder that contains `package.json`).
+
+### 2a. Collect (fetch your PRs from GitHub)
+
+Run this **one line** in the terminal. Replace **only** the part that says `PUT_YOUR_TOKEN_HERE` with your actual token (the `ghp_...` string). Leave the rest exactly as is, including the dates if you want Jan 1–Dec 31 of 2025.
+
+```bash
+GITHUB_TOKEN=PUT_YOUR_TOKEN_HERE yarn collect --start 2025-01-01 --end 2025-12-31 --output raw.json
+```
+
+- **Wrong:** `GITHUB_TOKEN = ghp_xxx` (no spaces around `=`)
+- **Wrong:** Forgetting the token and running `yarn collect` without `GITHUB_TOKEN=...` (it will say “GITHUB_TOKEN required”)
+- **Right:** One continuous line: `GITHUB_TOKEN=ghp_YourActualTokenHere yarn collect --start 2025-01-01 --end 2025-12-31 --output raw.json`
+
+**Checkpoint:** The command should finish without errors. You should see “Wrote raw.json” (or similar). There will now be a file called **raw.json** in the repo root. You do **not** paste this file into the app.
+
+### 2b. Normalize (turn raw.json into evidence.json)
+
+Run this **one line**:
+
+```bash
+yarn normalize --input raw.json --output evidence.json
+```
+
+**Checkpoint:** No errors. You now have a file named **evidence.json** in the repo root. **This is the file you paste or upload.** Not raw.json.
+
+**Different date range?** In 2a, change only `2025-01-01` and `2025-12-31` to your start and end dates (YYYY-MM-DD). Then run 2a, then 2b again.
+
+---
+
+## Step 3: Put that data into the app
+
+1. Open the app and go to the **Generate** page (“Generate my review”).
+2. Use **one** of these:
+   - **Upload:** Click **“Upload evidence.json”** and choose the file **evidence.json** from the repo root (the one you made in Step 2b).  
+   - **Paste:** Open **evidence.json** in a text editor, Select All, Copy, then click in the big text box on the Generate page and Paste.
+3. Click **“Generate review”**.
+
+**Wrong:** Pasting or uploading **raw.json** — the app will complain about invalid JSON or missing “contributions”. It must be **evidence.json**.
+
+---
+
+## If something breaks
+
+| What you see | What to do |
+|--------------|------------|
+| `GITHUB_TOKEN required` | You didn’t set the token. Run the 2a command again with `GITHUB_TOKEN=ghp_...` at the start (no spaces around `=`). |
+| `--start` / `--end` required | You didn’t pass dates. Use the full 2a command including `--start 2025-01-01 --end 2025-12-31` (or your dates). |
+| `Invalid JSON` or missing “contributions” in the app | You pasted **raw.json**. Use **evidence.json** (the file from `yarn normalize`). |
+| `yarn: command not found` | Install Node and Yarn, then run the commands from the repo root. |
+| No `evidence.json` after 2b | Run 2a first (so `raw.json` exists), then run 2b again. |
+
+---
+
+**TL;DR (CLI):** Token from GitHub → run 2a (collect) → run 2b (normalize) → upload or paste **evidence.json** in the app. Not raw.json.  
+**TL;DR (app):** Sign in with GitHub on the Generate page → Fetch my data → Generate review.

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,143 @@
+/**
+ * GitHub OAuth: redirect URL, token exchange, user fetch, callback/me/logout handlers.
+ */
+
+const GITHUB_AUTH = "https://github.com/login/oauth/authorize";
+const GITHUB_TOKEN = "https://github.com/login/oauth/access_token";
+const GITHUB_USER = "https://api.github.com/user";
+
+const SCOPES = {
+  public: "read:user public_repo",
+  private: "read:user repo",
+};
+
+/**
+ * @param {"public" | "private"} scope
+ * @param {string} state
+ * @param {string} redirectUri
+ * @param {string} clientId
+ * @returns {string}
+ */
+export function getAuthRedirectUrl(scope, state, redirectUri, clientId) {
+  const s = SCOPES[scope] || SCOPES.public;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: s,
+    state,
+  });
+  return `${GITHUB_AUTH}?${params.toString()}`;
+}
+
+/**
+ * @param {string} code
+ * @param {string} redirectUri
+ * @param {string} clientId
+ * @param {string} clientSecret
+ * @param {typeof fetch} fetchFn
+ * @returns {Promise<string>} access_token
+ */
+export async function exchangeCodeForToken(code, redirectUri, clientId, clientSecret, fetchFn) {
+  const res = await fetchFn(GITHUB_TOKEN, {
+    method: "POST",
+    headers: { Accept: "application/json", "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      redirect_uri: redirectUri,
+    }),
+  });
+  if (!res.ok) throw new Error(`Token exchange failed: ${res.status}`);
+  const data = await res.json();
+  if (data.error) throw new Error(data.error_description || data.error);
+  if (!data.access_token) throw new Error("No access_token in response");
+  return data.access_token;
+}
+
+/**
+ * @param {string} accessToken
+ * @param {typeof fetch} fetchFn
+ * @returns {Promise<{ login: string }>}
+ */
+export async function getGitHubUser(accessToken, fetchFn) {
+  const res = await fetchFn(GITHUB_USER, {
+    headers: { Authorization: `Bearer ${accessToken}`, Accept: "application/json" },
+  });
+  if (!res.ok) throw new Error(`User fetch failed: ${res.status}`);
+  const user = await res.json();
+  return { login: user.login };
+}
+
+/**
+ * @param {{ url?: string, headers?: { cookie?: string } }} req
+ * @param {{ writeHead: (code: number, headers?: object) => void, end: (body?: string) => void, setHeader: (k: string, v: string) => void }} res
+ * @param {{
+ *   getStateFromRequest: (req: any) => string | null,
+ *   setSessionCookie: (res: any, id: string, secret: string) => void,
+ *   createSession: (data: object) => string,
+ *   exchangeCodeForToken: (code: string, redirectUri: string) => Promise<string>,
+ *   getGitHubUser: (token: string) => Promise<{ login: string }>,
+ *   redirectUri: string,
+ *   sessionSecret: string,
+ *   scope?: string,
+ * }} deps
+ */
+export async function handleCallback(req, res, deps) {
+  const url = req.url || "";
+  const search = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+  const params = new URLSearchParams(search);
+  const code = params.get("code");
+  const stateParam = params.get("state");
+  const stateId = deps.getStateFromRequest(req);
+  const storedState = stateId ? deps.getAndRemoveOAuthState(stateId) : null;
+
+  if (!code || !stateParam || !storedState || stateParam !== storedState) {
+    res.writeHead(400);
+    res.end();
+    return;
+  }
+
+  const scope = stateParam.includes("_") ? stateParam.slice(0, stateParam.indexOf("_")) : (deps.scope || "public");
+  const redirectUri = deps.redirectUri;
+  const access_token = await deps.exchangeCodeForToken(code, redirectUri);
+  const user = await deps.getGitHubUser(access_token);
+  const sessionId = deps.createSession({
+    access_token,
+    login: user.login,
+    scope,
+  });
+  deps.setSessionCookie(res, sessionId, deps.sessionSecret);
+  res.writeHead(302, { Location: "/generate" });
+  res.end();
+}
+
+/**
+ * @param {{ headers?: object }} req
+ * @param {{ statusCode?: number, setHeader: (k: string, v: string) => void, end: (body?: string) => void }} res
+ * @param {{ getSessionIdFromRequest: (req: any) => string | null, getSession: (id: string) => { login: string, scope?: string } | undefined }} deps
+ */
+export function handleMe(req, res, deps) {
+  const sessionId = deps.getSessionIdFromRequest(req);
+  const session = sessionId ? deps.getSession(sessionId) : undefined;
+  if (!session) {
+    res.writeHead(401);
+    res.end();
+    return;
+  }
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ login: session.login, scope: session.scope }));
+}
+
+/**
+ * @param {{ headers?: object }} req
+ * @param {{ writeHead: (code: number) => void, end: () => void }} res
+ * @param {{ getSessionIdFromRequest: (req: any) => string | null, destroySession: (id: string) => void, clearSessionCookie: (res: any) => void }} deps
+ */
+export function handleLogout(req, res, deps) {
+  const sessionId = deps.getSessionIdFromRequest(req);
+  if (sessionId) deps.destroySession(sessionId);
+  deps.clearSessionCookie(res);
+  res.writeHead(204);
+  res.end();
+}

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,0 +1,97 @@
+import { createHmac } from "crypto";
+
+const COOKIE_NAME = "ar_session";
+
+/**
+ * @param {string} id
+ * @param {string} secret
+ * @returns {string}
+ */
+export function signSessionId(id, secret) {
+  const sig = createHmac("sha256", secret).update(id).digest("hex");
+  return `${id}.${sig}`;
+}
+
+/**
+ * @param {string} value
+ * @param {string} secret
+ * @returns {string | null}
+ */
+export function verifySessionId(value, secret) {
+  if (!value || typeof value !== "string") return null;
+  const i = value.lastIndexOf(".");
+  if (i <= 0) return null;
+  const id = value.slice(0, i);
+  const sig = value.slice(i + 1);
+  const expected = createHmac("sha256", secret).update(id).digest("hex");
+  return sig === expected ? id : null;
+}
+
+/**
+ * @param {{ headers?: { cookie?: string } }} req
+ * @param {string} secret
+ * @returns {string | null}
+ */
+export function getSessionIdFromRequest(req, secret) {
+  const cookie = req?.headers?.cookie;
+  if (!cookie) return null;
+  const match = cookie.match(new RegExp(`${COOKIE_NAME}=([^;]+)`));
+  if (!match) return null;
+  const value = decodeURIComponent(match[1].trim());
+  return verifySessionId(value, secret);
+}
+
+/**
+ * @param {{ setHeader: (k: string, v: string) => void }} res
+ * @param {string} sessionId
+ * @param {string} secret
+ * @param {{ secure?: boolean, maxAge?: number }} opts
+ */
+export function setSessionCookie(res, sessionId, secret, opts = {}) {
+  const value = signSessionId(sessionId, secret);
+  const secure = opts.secure ?? false;
+  const maxAge = opts.maxAge ?? 60 * 60 * 24 * 7; // 7 days
+  const parts = [
+    `${COOKIE_NAME}=${encodeURIComponent(value)}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    `Max-Age=${maxAge}`,
+  ];
+  if (secure) parts.push("Secure");
+  res.setHeader("Set-Cookie", parts.join("; "));
+}
+
+/**
+ * @param {{ setHeader: (k: string, v: string) => void }} res
+ */
+export function clearSessionCookie(res) {
+  res.setHeader(
+    "Set-Cookie",
+    `${COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`
+  );
+}
+
+const STATE_COOKIE = "ar_oauth_state";
+
+/**
+ * @param {{ setHeader: (k: string, v: string) => void }} res
+ * @param {string} state
+ */
+export function setStateCookie(res, state) {
+  res.setHeader(
+    "Set-Cookie",
+    `${STATE_COOKIE}=${encodeURIComponent(state)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=600`
+  );
+}
+
+/**
+ * @param {{ headers?: { cookie?: string } }} req
+ * @returns {string | null}
+ */
+export function getStateFromRequest(req) {
+  const cookie = req?.headers?.cookie;
+  if (!cookie) return null;
+  const match = cookie.match(new RegExp(`${STATE_COOKIE}=([^;]+)`));
+  return match ? decodeURIComponent(match[1].trim()) : null;
+}

--- a/lib/job-store.js
+++ b/lib/job-store.js
@@ -1,0 +1,79 @@
+/**
+ * In-memory job store for long-running collect/generate. Single-instance only.
+ * POST /api/collect or /api/generate starts a job and returns job_id; client polls GET /api/jobs/:id.
+ */
+
+const jobs = new Map();
+
+const STATUS = { PENDING: "pending", RUNNING: "running", DONE: "done", FAILED: "failed" };
+
+/**
+ * @param {string} type
+ * @param {string} [sessionId]
+ * @returns {string} job id
+ */
+export function createJob(type, sessionId) {
+  const id = `job_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+  const record = {
+    type,
+    status: STATUS.PENDING,
+    created_at: new Date().toISOString(),
+    progress: null,
+    result: null,
+    error: null,
+  };
+  if (sessionId != null) record.created_by = sessionId;
+  jobs.set(id, record);
+  return id;
+}
+
+/**
+ * @typedef {{ type: string, status: string, created_at: string, created_by?: string, progress?: string | null, result?: unknown, error?: string | null }} Job
+ * @returns {Job | undefined}
+ */
+export function getJob(id) {
+  return jobs.get(id);
+}
+
+/**
+ * @param {string} sessionId
+ * @returns {(Job & { id: string }) | null}
+ */
+export function getLatestJob(sessionId) {
+  const candidates = [];
+  for (const [id, job] of jobs) {
+    if (job.created_by !== sessionId) continue;
+    candidates.push({ id, ...job });
+  }
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => {
+    const c = (b.created_at || "").localeCompare(a.created_at || "");
+    return c !== 0 ? c : (b.id || "").localeCompare(a.id || "");
+  });
+  return candidates[0];
+}
+
+/** @param {string} id @param {Partial<Job>} update */
+export function updateJob(id, update) {
+  const job = jobs.get(id);
+  if (job) Object.assign(job, update);
+}
+
+/**
+ * Run fn in the background; update job to running, then done/result or failed/error.
+ * @param {string} id job id
+ * @param {(report: (p: { progress?: string }) => void) => Promise<unknown>} fn async work; call report({ progress }) to update
+ */
+export function runInBackground(id, fn) {
+  updateJob(id, { status: STATUS.RUNNING });
+  const report = (update) => updateJob(id, update);
+  fn(report)
+    .then((result) => updateJob(id, { status: STATUS.DONE, result, progress: null }))
+    .catch((err) =>
+      updateJob(id, {
+        status: STATUS.FAILED,
+        error: err.message || "Job failed",
+        progress: null,
+      })
+    );
+}

--- a/lib/run-pipeline.js
+++ b/lib/run-pipeline.js
@@ -23,7 +23,14 @@ export function extractJson(text) {
   return JSON.parse(text.slice(start, end));
 }
 
-export async function runPipeline(evidence, { apiKey = process.env.OPENAI_API_KEY, model = "gpt-4o-mini" } = {}) {
+const STEPS = [
+  { key: "themes", label: "Themes" },
+  { key: "bullets", label: "Impact bullets" },
+  { key: "stories", label: "STAR stories" },
+  { key: "self_eval", label: "Self-eval sections" },
+];
+
+export async function runPipeline(evidence, { apiKey = process.env.OPENAI_API_KEY, model = "gpt-4o-mini", onProgress } = {}) {
   if (!apiKey) throw new Error("OPENAI_API_KEY required");
   const openai = new OpenAI({ apiKey });
 
@@ -33,7 +40,13 @@ export async function runPipeline(evidence, { apiKey = process.env.OPENAI_API_KE
   const prompt30 = loadPrompt("30_star_stories.md");
   const prompt40 = loadPrompt("40_self_eval_sections.md");
 
+  const total = STEPS.length;
+  function progress(stepIndex, label) {
+    if (typeof onProgress === "function") onProgress({ stepIndex, total, step: STEPS[stepIndex - 1].key, label: label || STEPS[stepIndex - 1].label });
+  }
+
   // Step 1: cluster contributions into themes
+  progress(1);
   const input1 = JSON.stringify({ timeframe: evidence.timeframe, role_context_optional: evidence.role_context_optional, contributions: evidence.contributions }, null, 2);
   const res1 = await openai.chat.completions.create({
     model,
@@ -44,6 +57,7 @@ export async function runPipeline(evidence, { apiKey = process.env.OPENAI_API_KE
   });
   const themes = extractJson(res1.choices[0]?.message?.content ?? "{}");
   // Step 2: impact bullets (from themes + contributions)
+  progress(2);
   const input2 = JSON.stringify({ timeframe: evidence.timeframe, themes, contributions: evidence.contributions }, null, 2);
   const res2 = await openai.chat.completions.create({
     model,
@@ -54,6 +68,7 @@ export async function runPipeline(evidence, { apiKey = process.env.OPENAI_API_KE
   });
   const bullets = extractJson(res2.choices[0]?.message?.content ?? "{}");
   // Step 3: STAR stories
+  progress(3);
   const input3 = JSON.stringify({ timeframe: evidence.timeframe, themes, bullets_by_theme: bullets.bullets_by_theme, contributions: evidence.contributions }, null, 2);
   const res3 = await openai.chat.completions.create({
     model,
@@ -64,6 +79,7 @@ export async function runPipeline(evidence, { apiKey = process.env.OPENAI_API_KE
   });
   const stories = extractJson(res3.choices[0]?.message?.content ?? "{}");
   // Step 4: self-eval sections
+  progress(4);
   const input4 = JSON.stringify({
     timeframe: evidence.timeframe,
     role_context_optional: evidence.role_context_optional,

--- a/lib/session-store.js
+++ b/lib/session-store.js
@@ -1,0 +1,47 @@
+/**
+ * In-memory session store. Session id in cookie; token and identity stored server-side.
+ */
+
+const sessions = new Map();
+
+/**
+ * @param {{ access_token: string, login: string, scope?: string }} data
+ * @returns {string} session id
+ */
+export function createSession(data) {
+  const id = `sess_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+  sessions.set(id, {
+    ...data,
+    created_at: new Date().toISOString(),
+  });
+  return id;
+}
+
+/**
+ * @param {string} id
+ * @returns {{ access_token: string, login: string, scope?: string, created_at: string } | undefined}
+ */
+export function getSession(id) {
+  return sessions.get(id);
+}
+
+/**
+ * @param {string} id
+ */
+export function destroySession(id) {
+  sessions.delete(id);
+}
+
+const oauthStates = new Map();
+
+/** Store OAuth state by short id (id goes in cookie; state is sent to GitHub). */
+export function setOAuthState(id, state) {
+  oauthStates.set(id, state);
+}
+
+/** Retrieve and consume OAuth state. */
+export function getAndRemoveOAuthState(id) {
+  const state = oauthStates.get(id);
+  if (state) oauthStates.delete(id);
+  return state ?? null;
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",
+    "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage"
   },
   "type": "module",
@@ -34,6 +35,7 @@
     "@testing-library/react": "^16.3.2",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "4.0.18",
+    "@vitest/ui": "4.0.18",
     "jsdom": "^28.1.0",
     "vite": "^6.0.3",
     "vitest": "^4.0.18"

--- a/schemas/evidence.json
+++ b/schemas/evidence.json
@@ -16,7 +16,7 @@
       "additionalProperties": false
     },
     "role_context_optional": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "level": { "type": "string" },
         "job_family": { "type": "string" },

--- a/scripts/normalize.js
+++ b/scripts/normalize.js
@@ -161,7 +161,7 @@ function normalize(raw, start, end) {
   const rawCommits = raw.commits || [];
   const commitShaToPr = new Map(); // optional: if raw has pull_requests, we know which commits belong to PRs
   for (const pr of rawPrs) {
-    const shas = pr.commits || [];
+    const shas = Array.isArray(pr.commits) ? pr.commits : [];
     for (const c of shas) {
       const sha = typeof c === "string" ? c : (c.sha || c.commit?.sha);
       if (sha) commitShaToPr.set(sha, true);

--- a/src/Generate.css
+++ b/src/Generate.css
@@ -37,6 +37,68 @@
   color: var(--text);
 }
 
+.generate-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.generate-signed-in {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.generate-logout {
+  margin-left: 0.5rem;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.85rem;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.generate-logout:hover {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+.generate-oauth-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.generate-oauth-btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--bg);
+  background: var(--accent);
+  border-radius: 6px;
+  text-decoration: none;
+}
+
+.generate-oauth-btn:hover {
+  background: var(--accent-dim);
+}
+
+.generate-oauth-btn-private {
+  background: var(--text-muted);
+}
+
+.generate-oauth-btn-private:hover {
+  background: var(--text);
+}
+
+.generate-or {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
 .generate-main {
   flex: 1;
   max-width: 48rem;
@@ -296,6 +358,12 @@
   color: #e57373;
   margin: 0 0 1rem;
   font-size: 0.9rem;
+}
+
+.generate-progress {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
 }
 
 .generate-btn {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getAuthRedirectUrl,
+  exchangeCodeForToken,
+  getGitHubUser,
+  handleCallback,
+  handleMe,
+  handleLogout,
+} from "../lib/auth.js";
+import { createSession, getSession, destroySession } from "../lib/session-store.js";
+
+describe("auth", () => {
+  const clientId = "cid";
+  const clientSecret = "csec";
+  const secret = "sess-secret";
+
+  describe("getAuthRedirectUrl", () => {
+    it("builds GitHub OAuth URL with scope and state", () => {
+      const url = getAuthRedirectUrl("public", "state123", "https://app/cb", clientId);
+      expect(url).toContain("https://github.com/login/oauth/authorize");
+      expect(url).toContain("client_id=cid");
+      expect(url).toContain("redirect_uri=");
+      expect(url).toContain("state=state123");
+      expect(url).toContain("scope=");
+      expect(url).toContain("read%3Auser");
+      expect(url).toContain("public_repo");
+    });
+
+    it("uses repo scope for private", () => {
+      const url = getAuthRedirectUrl("private", "s", "https://x/cb", clientId);
+      expect(url).toContain("scope=");
+      expect(url).toContain("read%3Auser");
+      expect(url).toContain("repo");
+    });
+  });
+
+  describe("exchangeCodeForToken", () => {
+    it("returns access_token when GitHub responds ok", async () => {
+      const fetchFn = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ access_token: "gho_xyz" }),
+      });
+      const token = await exchangeCodeForToken("code1", "https://app/cb", clientId, clientSecret, fetchFn);
+      expect(token).toBe("gho_xyz");
+      expect(fetchFn).toHaveBeenCalledWith(
+        "https://github.com/login/oauth/access_token",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    it("throws when response not ok", async () => {
+      const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+      await expect(
+        exchangeCodeForToken("bad", "https://app/cb", clientId, clientSecret, fetchFn)
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("getGitHubUser", () => {
+    it("returns user login", async () => {
+      const fetchFn = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ login: "alice" }),
+      });
+      const user = await getGitHubUser("token", fetchFn);
+      expect(user.login).toBe("alice");
+      expect(fetchFn).toHaveBeenCalledWith("https://api.github.com/user", expect.any(Object));
+    });
+  });
+
+  describe("handleCallback", () => {
+    it("with valid code creates session and redirects", async () => {
+      const sessionId = createSession({ access_token: "old", login: "old", scope: "x" });
+      destroySession(sessionId);
+      const createSessionSpy = vi.fn((data) => {
+        return createSession(data);
+      });
+      const res = { writeHead: vi.fn(), end: vi.fn(), setHeader: vi.fn() };
+      const req = {
+        url: "/api/auth/callback/github?code=abc&state=st1",
+        headers: { cookie: "ar_oauth_state=st1" },
+      };
+      const fetchFn = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ access_token: "gho_new" }) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ login: "bob" }) });
+      const deps = {
+        getStateFromRequest: () => "st1",
+        getAndRemoveOAuthState: (id) => (id === "st1" ? "st1" : null),
+        setSessionCookie: vi.fn(),
+        setStateCookie: vi.fn(),
+        createSession: createSessionSpy,
+        exchangeCodeForToken: (code, redirectUri) =>
+          exchangeCodeForToken(code, redirectUri, clientId, clientSecret, fetchFn),
+        getGitHubUser: (token) => getGitHubUser(token, fetchFn),
+        redirectUri: "https://app/api/auth/callback/github",
+        sessionSecret: secret,
+      };
+      await handleCallback(req, res, deps);
+      expect(createSessionSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ access_token: "gho_new", login: "bob" })
+      );
+      expect(res.writeHead).toHaveBeenCalledWith(302, expect.objectContaining({ Location: expect.stringContaining("/generate") }));
+      expect(res.end).toHaveBeenCalled();
+    });
+
+    it("with invalid state returns 400", async () => {
+      const res = { writeHead: vi.fn(), end: vi.fn() };
+      const req = { url: "/api/auth/callback/github?code=abc&state=st1", headers: { cookie: "ar_oauth_state=wrong" } };
+      const deps = {
+        getStateFromRequest: () => "wrong",
+        getAndRemoveOAuthState: () => null,
+        setSessionCookie: vi.fn(),
+        createSession: vi.fn(),
+        redirectUri: "https://app/cb",
+        sessionSecret: secret,
+      };
+      await handleCallback(req, res, deps);
+      expect(res.writeHead).toHaveBeenCalledWith(400);
+      expect(deps.createSession).not.toHaveBeenCalled();
+    });
+
+    it("with missing state returns 400", async () => {
+      const res = { writeHead: vi.fn(), end: vi.fn() };
+      const req = { url: "/api/auth/callback/github?code=abc", headers: {} };
+      const deps = {
+        getStateFromRequest: () => null,
+        getAndRemoveOAuthState: () => null,
+        setSessionCookie: vi.fn(),
+        createSession: vi.fn(),
+        redirectUri: "https://app/cb",
+        sessionSecret: secret,
+      };
+      await handleCallback(req, res, deps);
+      expect(res.writeHead).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe("handleMe", () => {
+    it("returns login and scope when session valid", () => {
+      const id = createSession({ access_token: "t", login: "user1", scope: "read:user" });
+      const req = { headers: {} };
+      const res = { writeHead: vi.fn(), end: vi.fn(), setHeader: vi.fn() };
+      handleMe(req, res, {
+        getSessionIdFromRequest: () => id,
+        getSession: (sid) => (sid === id ? { login: "user1", scope: "read:user" } : undefined),
+      });
+      expect(res.writeHead).toHaveBeenCalledWith(200, { "Content-Type": "application/json" });
+      expect(res.end).toHaveBeenCalledWith(JSON.stringify({ login: "user1", scope: "read:user" }));
+    });
+
+    it("returns 401 when no session", () => {
+      const req = { headers: {} };
+      const res = { writeHead: vi.fn(), end: vi.fn(), setHeader: vi.fn() };
+      handleMe(req, res, {
+        getSessionIdFromRequest: () => null,
+        getSession: () => undefined,
+      });
+      expect(res.writeHead).toHaveBeenCalledWith(401);
+    });
+  });
+
+  describe("handleLogout", () => {
+    it("clears session and cookie", () => {
+      const id = createSession({ access_token: "t", login: "u", scope: "s" });
+      const req = { headers: {} };
+      const res = { writeHead: vi.fn(), end: vi.fn(), setHeader: vi.fn() };
+      const destroySessionFn = vi.fn();
+      const clearSessionCookie = vi.fn();
+      handleLogout(req, res, {
+        getSessionIdFromRequest: () => id,
+        destroySession: destroySessionFn,
+        clearSessionCookie,
+      });
+      expect(destroySessionFn).toHaveBeenCalledWith(id);
+      expect(clearSessionCookie).toHaveBeenCalledWith(res);
+      expect(res.writeHead).toHaveBeenCalledWith(204);
+    });
+  });
+});

--- a/test/cookies.test.js
+++ b/test/cookies.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  signSessionId,
+  verifySessionId,
+  getSessionIdFromRequest,
+  setSessionCookie,
+  clearSessionCookie,
+} from "../lib/cookies.js";
+
+const SECRET = "test-secret";
+
+describe("cookies", () => {
+  it("signSessionId and verifySessionId round-trip", () => {
+    const id = "sess_123";
+    const signed = signSessionId(id, SECRET);
+    expect(signed).not.toBe(id);
+    expect(verifySessionId(signed, SECRET)).toBe(id);
+  });
+
+  it("verifySessionId returns null for tampered value", () => {
+    const signed = signSessionId("sess_123", SECRET);
+    expect(verifySessionId(signed + "x", SECRET)).toBeNull();
+    expect(verifySessionId("invalid", SECRET)).toBeNull();
+  });
+
+  it("getSessionIdFromRequest returns id when cookie present and valid", () => {
+    const signed = signSessionId("sess_abc", SECRET);
+    const req = { headers: { cookie: `ar_session=${encodeURIComponent(signed)}` } };
+    expect(getSessionIdFromRequest(req, SECRET)).toBe("sess_abc");
+  });
+
+  it("getSessionIdFromRequest returns null when no cookie", () => {
+    const req = { headers: {} };
+    expect(getSessionIdFromRequest(req, SECRET)).toBeNull();
+  });
+
+  it("setSessionCookie sets Set-Cookie header", () => {
+    const res = { setHeader: (k, v) => { res._headers = res._headers || {}; res._headers[k] = v; }, _headers: {} };
+    setSessionCookie(res, "sess_xyz", SECRET, {});
+    expect(res._headers["Set-Cookie"]).toBeDefined();
+    expect(res._headers["Set-Cookie"]).toContain("ar_session=");
+    expect(res._headers["Set-Cookie"]).toContain("HttpOnly");
+  });
+
+  it("clearSessionCookie sets Set-Cookie with Max-Age=0", () => {
+    const res = { setHeader: (k, v) => { res._headers = res._headers || {}; res._headers[k] = v; }, _headers: {} };
+    clearSessionCookie(res);
+    expect(res._headers["Set-Cookie"]).toContain("Max-Age=0");
+  });
+});

--- a/test/generate-review.test.js
+++ b/test/generate-review.test.js
@@ -6,12 +6,12 @@ import { randomUUID } from "crypto";
 import { runGenerateReview, parseArgs } from "../scripts/generate-review.js";
 
 describe("parseArgs", () => {
-  it("defaults input to evidence.json and outDir to cwd", () => {
+  it("defaults input to evidence.json and outDir to ./out", () => {
     const orig = process.argv.slice(2);
     process.argv = ["node", "generate-review.js"];
     const out = parseArgs();
     expect(out.input).toContain("evidence.json");
-    expect(out.outDir).toBe(process.cwd());
+    expect(out.outDir).toBe(join(process.cwd(), "out"));
     process.argv = ["node", "generate-review.js", ...orig];
   });
 

--- a/test/job-store.test.js
+++ b/test/job-store.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createJob, getJob, getLatestJob, updateJob, runInBackground } from "../lib/job-store.js";
+
+describe("job-store", () => {
+  beforeEach(() => {
+    // In-memory store; tests use unique sessionIds to avoid collisions
+  });
+
+  it("createJob(type, sessionId) stores created_by", () => {
+    const id = createJob("collect", "sess_abc");
+    const job = getJob(id);
+    expect(job).toBeDefined();
+    expect(job.type).toBe("collect");
+    expect(job.created_by).toBe("sess_abc");
+    expect(job.status).toBe("pending");
+  });
+
+  it("createJob(type) without sessionId works for backward compat", () => {
+    const id = createJob("generate");
+    const job = getJob(id);
+    expect(job).toBeDefined();
+    expect(job.type).toBe("generate");
+    expect(job.created_by).toBeUndefined();
+  });
+
+  it("getLatestJob(sessionId) returns most recent job for that session", async () => {
+    const sid = "sess_" + Date.now();
+    const id1 = createJob("collect", sid);
+    await new Promise((r) => setTimeout(r, 2));
+    const id2 = createJob("generate", sid);
+    const latest = getLatestJob(sid);
+    expect(latest).toBeDefined();
+    expect(latest?.id).toBe(id2);
+    expect(latest?.type).toBe("generate");
+  });
+
+  it("getLatestJob(sessionId) returns null when no jobs for session", () => {
+    expect(getLatestJob("sess_nonexistent")).toBeNull();
+  });
+
+  it("getLatestJob ignores jobs from other sessions", () => {
+    createJob("collect", "sess_other");
+    const id = createJob("collect", "sess_mine");
+    expect(getLatestJob("sess_mine")?.id).toBe(id);
+  });
+
+  it("getJob(id) still works", () => {
+    const id = createJob("collect", "sess_x");
+    const job = getJob(id);
+    expect(job?.type).toBe("collect");
+    expect(job?.created_by).toBe("sess_x");
+  });
+
+  it("runInBackground updates job to done with result", async () => {
+    const id = createJob("collect", "sess_y");
+    runInBackground(id, () => Promise.resolve({ contributions: [] }));
+    await new Promise((r) => setTimeout(r, 50));
+    const job = getJob(id);
+    expect(job?.status).toBe("done");
+    expect(job?.result).toEqual({ contributions: [] });
+  });
+});

--- a/test/session-store.test.js
+++ b/test/session-store.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createSession, getSession, destroySession, setOAuthState, getAndRemoveOAuthState } from "../lib/session-store.js";
+
+describe("session-store", () => {
+  beforeEach(() => {
+    // Session store is in-memory; we can't clear it without an API, so we use unique ids per test
+  });
+
+  it("createSession returns id and stores data", () => {
+    const data = { access_token: "tok", login: "alice", scope: "read:user" };
+    const id = createSession(data);
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+    const session = getSession(id);
+    expect(session).toBeDefined();
+    expect(session.access_token).toBe("tok");
+    expect(session.login).toBe("alice");
+    expect(session.scope).toBe("read:user");
+    expect(session.created_at).toBeDefined();
+  });
+
+  it("getSession(id) returns undefined for unknown id", () => {
+    expect(getSession("nonexistent")).toBeUndefined();
+  });
+
+  it("destroySession(id) removes session", () => {
+    const id = createSession({ access_token: "x", login: "bob", scope: "repo" });
+    expect(getSession(id)).toBeDefined();
+    destroySession(id);
+    expect(getSession(id)).toBeUndefined();
+  });
+
+  it("getSession after destroy returns undefined", () => {
+    const id = createSession({ access_token: "y", login: "charlie", scope: "public_repo" });
+    destroySession(id);
+    expect(getSession(id)).toBeUndefined();
+  });
+
+  describe("OAuth state", () => {
+    it("getAndRemoveOAuthState returns and removes state", () => {
+      setOAuthState("oid_abc", "public_st_123");
+      expect(getAndRemoveOAuthState("oid_abc")).toBe("public_st_123");
+      expect(getAndRemoveOAuthState("oid_abc")).toBeNull();
+    });
+    it("getAndRemoveOAuthState returns null for unknown id", () => {
+      expect(getAndRemoveOAuthState("unknown")).toBeNull();
+    });
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,28 @@
-// Dev server: serves the React app and two API routes.
-// POST /api/generate — body: evidence JSON → run pipeline → themes, bullets, stories, self_eval.
-// POST /api/collect — body: { token, start_date, end_date } → fetch GitHub + normalize → evidence JSON.
-import { defineConfig } from "vite";
+// Dev server: serves the React app and API routes.
+// Auth: GET /api/auth/github, GET /api/auth/callback/github, GET /api/auth/me, POST /api/auth/logout.
+// POST /api/collect → 202 { job_id }; POST /api/generate → 202 { job_id }. Poll GET /api/jobs/:id for status/result.
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { runPipeline } from "./lib/run-pipeline.js";
 import { collectAndNormalize } from "./lib/collect-and-normalize.js";
+import { validateEvidence } from "./lib/validate-evidence.js";
+import { createJob, getJob, getLatestJob, runInBackground } from "./lib/job-store.js";
+import { createSession, getSession, destroySession, setOAuthState, getAndRemoveOAuthState } from "./lib/session-store.js";
+import {
+  getAuthRedirectUrl,
+  exchangeCodeForToken,
+  getGitHubUser,
+  handleCallback,
+  handleMe,
+  handleLogout,
+} from "./lib/auth.js";
+import {
+  getSessionIdFromRequest,
+  setSessionCookie,
+  clearSessionCookie,
+  setStateCookie,
+  getStateFromRequest,
+} from "./lib/cookies.js";
 
 const DATE_YYYY_MM_DD = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -28,41 +46,155 @@ function respondJson(res, status, data) {
   res.end(JSON.stringify(data));
 }
 
+function randomState() {
+  return `st_${Date.now()}_${Math.random().toString(36).slice(2, 15)}`;
+}
+
 function apiRoutesPlugin() {
   return {
     name: "api-routes",
-    configureServer(server) {
-      server.middlewares.use("/api/generate", async (req, res) => {
+    configureServer(server, config) {
+      const mode = config?.mode ?? "development";
+      const env = loadEnv(mode, process.cwd(), "");
+      const sessionSecret = env.SESSION_SECRET || process.env.SESSION_SECRET || "dev-secret";
+      const clientId = env.GITHUB_CLIENT_ID || process.env.GITHUB_CLIENT_ID;
+      const clientSecret = env.GITHUB_CLIENT_SECRET || process.env.GITHUB_CLIENT_SECRET;
+
+      server.middlewares.use("/api/auth", (req, res, next) => {
+        const path = req.url?.split("?")[0] || "";
+        const isSecure = req.headers["x-forwarded-proto"] === "https";
+        const host = req.headers.host || "localhost:5173";
+        const origin = `${isSecure ? "https" : "http"}://${host}`;
+        const redirectUri = `${origin}/api/auth/callback/github`;
+
+        if (req.method === "GET" && path === "/github") {
+          if (!clientId) {
+            respondJson(res, 500, { error: "GITHUB_CLIENT_ID not set. Add it to .env and restart the dev server." });
+            return;
+          }
+          const scope = (new URL(req.url || "", "http://x").searchParams.get("scope")) || "public";
+          const state = `${scope}_${randomState()}`;
+          const stateId = `oid_${Math.random().toString(36).slice(2, 14)}`;
+          setOAuthState(stateId, state);
+          setStateCookie(res, stateId);
+          const url = getAuthRedirectUrl(scope, state, redirectUri, clientId);
+          res.writeHead(302, { Location: url });
+          res.end();
+          return;
+        }
+
+        if (req.method === "GET" && path === "/callback/github") {
+          const fullUrl = `${origin}${req.url || ""}`;
+          const callbackReq = { ...req, url: fullUrl };
+          handleCallback(callbackReq, res, {
+            getStateFromRequest: () => getStateFromRequest(req),
+            getAndRemoveOAuthState,
+            setSessionCookie,
+            createSession,
+            exchangeCodeForToken: (code, uri) =>
+              exchangeCodeForToken(code, uri, clientId, clientSecret, fetch),
+            getGitHubUser: (token) => getGitHubUser(token, fetch),
+            redirectUri,
+            sessionSecret,
+          }).catch((e) => {
+            res.writeHead(500);
+            res.end(e.message || "Callback failed");
+          });
+          return;
+        }
+
+        if (req.method === "GET" && path === "/me") {
+          handleMe(req, res, {
+            getSessionIdFromRequest: (r) => getSessionIdFromRequest(r, sessionSecret),
+            getSession: getSession,
+          });
+          return;
+        }
+
+        if (req.method === "POST" && path === "/logout") {
+          handleLogout(req, res, {
+            getSessionIdFromRequest: (r) => getSessionIdFromRequest(r, sessionSecret),
+            destroySession,
+            clearSessionCookie,
+          });
+          return;
+        }
+
+        next();
+      });
+
+      server.middlewares.use("/api/jobs", (req, res, next) => {
+        if (req.method !== "GET") {
+          next();
+          return;
+        }
+        const path = (req.url?.split("?")[0] || "").replace(/^\/+/, "") || "";
+        if (!path) {
+          const sessionId = getSessionIdFromRequest(req, sessionSecret);
+          const latest = sessionId ? getLatestJob(sessionId) : null;
+          respondJson(res, 200, latest ? { latest } : { latest: null });
+          return;
+        }
+        const id = decodeURIComponent(path);
+        const job = getJob(id);
+        if (!job) {
+          respondJson(res, 404, { error: "Job not found" });
+          return;
+        }
+        respondJson(res, 200, job);
+      });
+
+      server.middlewares.use("/api/generate", async (req, res, next) => {
         if (req.method !== "POST") {
-          respondJson(res, 405, { error: "Method not allowed" });
+          next();
           return;
         }
         try {
           const evidence = await readJsonBody(req);
-          const result = await runPipeline(evidence);
-          respondJson(res, 200, result);
+          const validation = validateEvidence(evidence);
+          if (!validation.valid) {
+            const msg = validation.errors?.length
+              ? validation.errors.map((e) => `${e.instancePath || "evidence"} ${e.message}`).join("; ")
+              : "Evidence must have timeframe (start_date, end_date) and contributions array.";
+            respondJson(res, 400, { error: "Invalid evidence", details: msg });
+            return;
+          }
+          const jobId = createJob("generate");
+          runInBackground(jobId, (report) =>
+            runPipeline(evidence, {
+              onProgress: ({ stepIndex, total, label }) => report({ progress: `${stepIndex}/${total} ${label}` }),
+            })
+          );
+          respondJson(res, 202, { job_id: jobId });
         } catch (e) {
           respondJson(res, 500, { error: e.message || "Pipeline failed" });
         }
       });
 
-      server.middlewares.use("/api/collect", async (req, res) => {
+      server.middlewares.use("/api/collect", async (req, res, next) => {
         if (req.method !== "POST") {
-          respondJson(res, 405, { error: "Method not allowed" });
+          next();
           return;
         }
         try {
-          const { token, start_date, end_date } = await readJsonBody(req);
-          if (!token || typeof token !== "string") {
-            respondJson(res, 400, { error: "token required" });
-            return;
-          }
+          const body = await readJsonBody(req);
+          const { start_date, end_date } = body;
           if (!DATE_YYYY_MM_DD.test(start_date) || !DATE_YYYY_MM_DD.test(end_date)) {
             respondJson(res, 400, { error: "start_date and end_date must be YYYY-MM-DD" });
             return;
           }
-          const evidence = await collectAndNormalize({ token, start_date, end_date });
-          respondJson(res, 200, evidence);
+          const sessionId = getSessionIdFromRequest(req, sessionSecret);
+          const session = sessionId ? getSession(sessionId) : undefined;
+          const token = session?.access_token ?? body.token;
+          if (!token || typeof token !== "string") {
+            respondJson(res, 401, { error: "token required (sign in with GitHub or send token in body)" });
+            return;
+          }
+          const jobId = createJob("collect", sessionId || undefined);
+          runInBackground(jobId, () =>
+            collectAndNormalize({ token, start_date, end_date })
+          );
+          respondJson(res, 202, { job_id: jobId });
         } catch (e) {
           const status = (e.message || "").includes("401") || (e.message || "").includes("403") ? 401 : 500;
           respondJson(res, status, { error: e.message || "Fetch failed" });

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,6 +416,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@polka/url@^1.0.0-next.24":
+  version "1.0.0-next.29"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
+  integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
+
 "@rolldown/pluginutils@1.0.0-beta.27":
   version "1.0.0-beta.27"
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz#47d2bf4cef6d470b22f5831b420f8964e0bf755f"
@@ -718,6 +723,19 @@
   resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.0.18.tgz#ba0f20503fb6d08baf3309d690b3efabdfa88762"
   integrity sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==
 
+"@vitest/ui@4.0.18":
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/@vitest/ui/-/ui-4.0.18.tgz#ae5765c34e98bb5d7294eb38d624a87f7c8b0399"
+  integrity sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==
+  dependencies:
+    "@vitest/utils" "4.0.18"
+    fflate "^0.8.2"
+    flatted "^3.3.3"
+    pathe "^2.0.3"
+    sirv "^3.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.0.3"
+
 "@vitest/utils@4.0.18":
   version "4.0.18"
   resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.0.18.tgz#9636b16d86a4152ec68a8d6859cff702896433d4"
@@ -952,6 +970,16 @@ fdir@^6.4.4, fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
+fflate@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
+flatted@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
+  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -1136,6 +1164,11 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+mrmime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.1.tgz#bc3e87f7987853a54c9850eeb1f1078cd44adddc"
+  integrity sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==
+
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -1307,6 +1340,15 @@ siginfo@^2.0.0:
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
+sirv@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-3.0.2.tgz#f775fccf10e22a40832684848d636346f41cd970"
+  integrity sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==
+  dependencies:
+    "@polka/url" "^1.0.0-next.24"
+    mrmime "^2.0.0"
+    totalist "^3.0.0"
+
 source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -1375,6 +1417,11 @@ tldts@^7.0.5:
   integrity sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==
   dependencies:
     tldts-core "^7.0.23"
+
+totalist@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
+  integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
 
 tough-cookie@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## Summary

Implements the plan: GitHub OAuth sign-in, session and job store, background collect/generate with in-app polling and latest-job restore.

## Changes

- **Auth**: GET `/api/auth/github` (scope=public|private), GET `/api/auth/callback/github`, GET `/api/auth/me`, POST `/api/auth/logout`. Session store (in-memory), signed cookie. OAuth state stored server-side (short id in cookie) to avoid callback 400.
- **Jobs**: `createJob(type, sessionId)`, `getLatestJob(sessionId)`. GET `/api/jobs` with no id returns `{ latest }` for current session.
- **Collect**: POST `/api/collect` uses session token when logged in (no token in body); fallback to body token. Returns 202 + job_id; jobs tied to session.
- **UI**: Sign in with GitHub (public/private), or paste token. When signed in: date range + Fetch my data; on load, GET `/api/jobs` and prefill evidence if latest job is done.
- **Env**: `loadEnv()` in Vite plugin so `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` / `SESSION_SECRET` from `.env` are used.
- **Docs**: OAuth as primary path in `docs/how-to-get-evidence.md`.

## Testing

- `yarn test run` — 64 tests pass.
- `yarn build` — succeeds.