### PR TITLE
Refactor: #24 shared CSS primitives, #25 normalizer base factory, TDD in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ Turn GitHub contribution evidence into an evidence-backed annual review draft: t
   ]
 }
 
+## Development
+- **TDD when possible:** For new behavior or non-trivial changes, write or update tests first (Vitest in `test/`), then implement until tests pass. For bugfixes, add a failing test that reproduces the bug, then fix.
+- Run `yarn test` before committing; ensure builds and tests pass before opening PRs.
+
 ## Notes
 - Prefer PRs and reviews as primary evidence.
 - Keep outputs copy/paste friendly; avoid long prose.

--- a/src/Generate.css
+++ b/src/Generate.css
@@ -1,8 +1,4 @@
-.generate {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
+/* Layout: .generate → primitives.css */
 
 .generate-header {
   display: flex;

--- a/src/Landing.css
+++ b/src/Landing.css
@@ -1,17 +1,4 @@
-/* ─── Layout ─── */
-
-.landing {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.container {
-  max-width: 64rem;
-  margin: 0 auto;
-  padding: 0 1.5rem;
-  width: 100%;
-}
+/* Layout: .landing, .container → primitives.css */
 
 .auth-error-banner {
   background: var(--surface-warn, rgba(180, 80, 40, 0.15));
@@ -219,59 +206,7 @@
   color: var(--accent);
 }
 
-/* ─── Buttons ─── */
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-family: var(--font-sans);
-  font-weight: 600;
-  border: 1px solid transparent;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  text-decoration: none;
-}
-
-.btn-lg {
-  padding: 0.85rem 1.75rem;
-  font-size: 0.95rem;
-}
-
-.btn-primary {
-  background: var(--accent);
-  color: var(--bg);
-  border-color: var(--accent);
-  box-shadow: 0 0 24px rgba(201, 162, 39, 0.15), 0 1px 2px rgba(0, 0, 0, 0.3);
-}
-
-.btn-primary:hover {
-  background: #d4ad2e;
-  border-color: #d4ad2e;
-  color: var(--bg);
-  box-shadow: 0 0 32px rgba(201, 162, 39, 0.25), 0 2px 8px rgba(0, 0, 0, 0.4);
-  transform: translateY(-1px);
-}
-
-.btn-arrow {
-  transition: transform 0.2s;
-}
-
-.btn-primary:hover .btn-arrow {
-  transform: translateX(3px);
-}
-
-.btn-ghost {
-  background: transparent;
-  color: var(--text-muted);
-  border-color: var(--border);
-}
-
-.btn-ghost:hover {
-  color: var(--text);
-  border-color: var(--text-muted);
-}
+/* Buttons: .btn, .btn-lg, .btn-primary, .btn-ghost → primitives.css */
 
 /* ─── Proof bar ─── */
 
@@ -300,22 +235,7 @@
   border-bottom: 1px solid var(--border);
 }
 
-.section-kicker {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: var(--accent);
-  font-weight: 600;
-  margin: 0 0 0.75rem;
-}
-
-.section-title {
-  font-size: clamp(1.5rem, 3.5vw, 2.25rem);
-  font-weight: 700;
-  line-height: 1.2;
-  margin: 0 0 2.5rem;
-  color: var(--text);
-}
+/* .section-kicker, .section-title → primitives.css */
 
 /* ─── Feature grid ─── */
 
@@ -408,14 +328,8 @@
   margin-bottom: 0;
 }
 
-.mono {
-  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
-  font-size: 0.8rem;
-  color: var(--text-muted);
-}
-
-.text-muted {
-  color: var(--text-muted);
+/* .mono, .text-muted → primitives.css */
+.compare-body .text-muted {
   opacity: 0.6;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
   --accent-dim: #9a7b1a;
   --border: #2a2a2c;
   --font-sans: "Plus Jakarta Sans", system-ui, -apple-system, sans-serif;
+  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", monospace;
 }
 
 * {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom/client";
 import "./posthog";
 import App from "./App";
 import "./index.css";
+import "./primitives.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/src/primitives.css
+++ b/src/primitives.css
@@ -1,0 +1,169 @@
+/* Shared CSS primitives for Landing and Generate. Use with page-specific overrides. */
+
+/* ─── Layout ─── */
+
+.page,
+.landing,
+.generate {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.container {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  width: 100%;
+}
+
+/* ─── Buttons ─── */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-decoration: none;
+}
+
+.btn-sm {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+.btn-lg {
+  padding: 0.85rem 1.75rem;
+  font-size: 0.95rem;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+  box-shadow: 0 0 24px rgba(201, 162, 39, 0.15), 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.btn-primary:hover {
+  background: #d4ad2e;
+  border-color: #d4ad2e;
+  color: var(--bg);
+  box-shadow: 0 0 32px rgba(201, 162, 39, 0.25), 0 2px 8px rgba(0, 0, 0, 0.4);
+  transform: translateY(-1px);
+}
+
+.btn-arrow {
+  transition: transform 0.2s;
+}
+
+.btn-primary:hover .btn-arrow {
+  transform: translateX(3px);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border);
+}
+
+.btn-ghost:hover {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+/* ─── Card / panel ─── */
+
+.card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+/* ─── Forms ─── */
+
+.input-base {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+}
+
+.input-base::placeholder {
+  color: var(--text-muted);
+  opacity: 0.8;
+}
+
+.textarea-base {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  resize: vertical;
+}
+
+.textarea-base:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* ─── Typography ─── */
+
+.kicker,
+.section-kicker {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+}
+
+.section-title {
+  font-size: clamp(1.5rem, 3.5vw, 2.25rem);
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0 0 2.5rem;
+  color: var(--text);
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.text-muted {
+  color: var(--text-muted);
+}
+
+.text-muted-opacity {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+/* Code / pre block base */
+.pre-block {
+  margin: 0;
+  padding: 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: auto;
+}


### PR DESCRIPTION
Closes #24, #25 (parent: #27).

**#24 – Shared CSS primitives**
- Added `src/primitives.css`: layout (`.landing`, `.generate`, `.page`), `.container`, buttons (`.btn`, `.btn-primary`, `.btn-ghost`), `.card`, `.input-base`/`.textarea-base`, `.kicker`/`.section-kicker`, `.section-title`, `.mono`, `.text-muted`, `.pre-block`.
- Wired in `main.jsx`; added `--font-mono` in `index.css`.
- `Landing.css` and `Generate.css` now import/use primitives and removed duplicated rules.

**#25 – Normalizer base factory**
- `scripts/normalize.js`: added `createContribution(overrides)`; refactored `normalizePr`, `normalizeReview`, `normalizeRelease`, `normalizeCommit` to use it.

**AGENTS.md**
- Development section: TDD when possible, run `yarn test` before commit.

- [x] `yarn test` (97 tests)
- [x] `yarn build`