### PR TITLE
Refactor: Add shared parseArgs utility for CLI scripts

### DIFF
--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -1,0 +1,44 @@
+/**
+ * Schema-driven CLI argument parser. Use from scripts to avoid duplicated parseArgs logic.
+ *
+ * @param {{ flags: Array<{ name: string, option: string, type: 'string' | 'boolean' }>, positionals?: Array<{ name: string }>, defaults?: Record<string, unknown | (() => unknown)> }} schema
+ * @param {string[]} [argv=process.argv.slice(2)]
+ * @returns {Record<string, unknown>}
+ */
+export function parseArgs(schema, argv = process.argv.slice(2)) {
+  const result = {};
+  const positionals = [];
+
+  for (const f of schema.flags ?? []) {
+    result[f.name] = f.type === "boolean" ? false : null;
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const flag = schema.flags?.find((f) => f.option === arg);
+    if (flag) {
+      if (flag.type === "boolean") {
+        result[flag.name] = true;
+      } else if (argv[i + 1] != null) {
+        result[flag.name] = argv[++i];
+      }
+      continue;
+    }
+    if (!arg.startsWith("--")) {
+      positionals.push(arg);
+    }
+  }
+
+  for (let j = 0; j < (schema.positionals ?? []).length; j++) {
+    const p = schema.positionals[j];
+    result[p.name] = positionals[j] ?? null;
+  }
+
+  for (const [key, val] of Object.entries(schema.defaults ?? {})) {
+    if (result[key] == null) {
+      result[key] = typeof val === "function" ? val() : val;
+    }
+  }
+
+  return result;
+}

--- a/scripts/collect-github.js
+++ b/scripts/collect-github.js
@@ -6,21 +6,23 @@
 
 import { writeFileSync } from "fs";
 import { fileURLToPath } from "url";
+import { parseArgs as parseArgsBase } from "../lib/parse-args.js";
 
 const GITHUB_GRAPHQL = "https://api.github.com/graphql";
 
 const SEARCH_PR_PAGE_SIZE = 100;
 
-function parseArgs() {
-  const args = process.argv.slice(2);
-  let start = null, end = null, output = null, noReviews = false;
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--start" && args[i + 1]) start = args[++i];
-    else if (args[i] === "--end" && args[i + 1]) end = args[++i];
-    else if (args[i] === "--output" && args[i + 1]) output = args[++i];
-    else if (args[i] === "--no-reviews") noReviews = true;
-  }
-  return { start, end, output, noReviews };
+const COLLECT_GITHUB_SCHEMA = {
+  flags: [
+    { name: "start", option: "--start", type: "string" },
+    { name: "end", option: "--end", type: "string" },
+    { name: "output", option: "--output", type: "string" },
+    { name: "noReviews", option: "--no-reviews", type: "boolean" },
+  ],
+};
+
+function parseArgs(argv) {
+  return parseArgsBase(COLLECT_GITHUB_SCHEMA, argv);
 }
 
 export { parseArgs };

--- a/scripts/generate-review.js
+++ b/scripts/generate-review.js
@@ -7,10 +7,20 @@
 import { readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import { parseArgs as parseArgsBase } from "../lib/parse-args.js";
 import { runPipeline } from "../lib/run-pipeline.js";
 import { generateMarkdown } from "../lib/generate-markdown.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const GENERATE_REVIEW_SCHEMA = {
+  flags: [{ name: "outDir", option: "--out", type: "string" }],
+  positionals: [{ name: "input" }],
+  defaults: {
+    input: () => join(process.cwd(), "evidence.json"),
+    outDir: () => join(process.cwd(), "out"),
+  },
+};
 
 const STEP_LABELS = ["Themes", "Impact bullets", "STAR stories", "Self-eval sections"];
 const BAR_WIDTH = 16;
@@ -66,18 +76,8 @@ function onStepProgress(stepIndex, total, label, contributionCount = 0) {
   }
 }
 
-function parseArgs() {
-  const args = process.argv.slice(2);
-  let input = null;
-  let outDir = join(process.cwd(), "out");
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--out" && args[i + 1]) {
-      outDir = args[++i];
-    } else if (!args[i].startsWith("--")) {
-      input = args[i];
-    }
-  }
-  return { input: input || join(process.cwd(), "evidence.json"), outDir };
+function parseArgs(argv) {
+  return parseArgsBase(GENERATE_REVIEW_SCHEMA, argv);
 }
 
 export { parseArgs };

--- a/scripts/normalize.js
+++ b/scripts/normalize.js
@@ -6,19 +6,21 @@
 import { readFileSync, writeFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import { parseArgs as parseArgsBase } from "../lib/parse-args.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-function parseArgs() {
-  const args = process.argv.slice(2);
-  const out = { input: null, output: null, start: null, end: null };
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--input" && args[i + 1]) out.input = args[++i];
-    else if (args[i] === "--output" && args[i + 1]) out.output = args[++i];
-    else if (args[i] === "--start" && args[i + 1]) out.start = args[++i];
-    else if (args[i] === "--end" && args[i + 1]) out.end = args[++i];
-  }
-  return out;
+const NORMALIZE_SCHEMA = {
+  flags: [
+    { name: "input", option: "--input", type: "string" },
+    { name: "output", option: "--output", type: "string" },
+    { name: "start", option: "--start", type: "string" },
+    { name: "end", option: "--end", type: "string" },
+  ],
+};
+
+function parseArgs(argv) {
+  return parseArgsBase(NORMALIZE_SCHEMA, argv);
 }
 
 function parseDate(s) {

--- a/test/parse-args.test.js
+++ b/test/parse-args.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { parseArgs } from "../lib/parse-args.js";
+
+describe("parseArgs", () => {
+  it("parses string flags", () => {
+    const schema = {
+      flags: [
+        { name: "start", option: "--start", type: "string" },
+        { name: "end", option: "--end", type: "string" },
+      ],
+    };
+    const out = parseArgs(schema, ["--start", "2025-01-01", "--end", "2025-12-31"]);
+    expect(out.start).toBe("2025-01-01");
+    expect(out.end).toBe("2025-12-31");
+  });
+
+  it("parses boolean flags", () => {
+    const schema = {
+      flags: [{ name: "noReviews", option: "--no-reviews", type: "boolean" }],
+    };
+    expect(parseArgs(schema, []).noReviews).toBe(false);
+    expect(parseArgs(schema, ["--no-reviews"]).noReviews).toBe(true);
+  });
+
+  it("collects positionals and applies defaults", () => {
+    const schema = {
+      flags: [{ name: "outDir", option: "--out", type: "string" }],
+      positionals: [{ name: "input" }],
+      defaults: {
+        input: () => "/default/evidence.json",
+        outDir: () => "/default/out",
+      },
+    };
+    const out = parseArgs(schema, ["/path/to/ev.json", "--out", "/out"]);
+    expect(out.input).toBe("/path/to/ev.json");
+    expect(out.outDir).toBe("/out");
+  });
+
+  it("applies defaults when positionals and flags missing", () => {
+    const schema = {
+      flags: [{ name: "outDir", option: "--out", type: "string" }],
+      positionals: [{ name: "input" }],
+      defaults: {
+        input: () => "/default/evidence.json",
+        outDir: () => "/default/out",
+      },
+    };
+    const out = parseArgs(schema, []);
+    expect(out.input).toBe("/default/evidence.json");
+    expect(out.outDir).toBe("/default/out");
+  });
+});


### PR DESCRIPTION
## Summary

Implements #23: replace duplicated `parseArgs()` logic in the three CLI scripts with a single schema-driven utility.

## Changes

- **lib/parse-args.js** – New shared parser: `parseArgs(schema, argv?)` with:
  - `flags`: `{ name, option, type: 'string' | 'boolean' }`
  - `positionals`: optional list for non-flag args
  - `defaults`: optional values/functions applied when missing
- **scripts/collect-github.js** – Uses shared util (`--start`, `--end`, `--output`, `--no-reviews`).
- **scripts/normalize.js** – Uses shared util (`--input`, `--output`, `--start`, `--end`).
- **scripts/generate-review.js** – Uses shared util (positional input, `--out`), with defaults for input path and out dir.
- **test/parse-args.test.js** – Unit tests for the shared parser.

CLI behaviour and existing tests unchanged (99 tests pass).