### PR TITLE
Generate page: 3 tabs, auth failure on /generate, date picker after sign-in

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -121,7 +121,7 @@ export async function handleCallback(
   const fail = (reason: string) => {
     log("auth_callback_fail", reason);
     deps.clearStateCookie(res);
-    res.writeHead(302, { Location: "/?error=auth_failed" });
+    res.writeHead(302, { Location: "/generate?error=auth_failed" });
     res.end();
   };
 

--- a/src/CollectForm.tsx
+++ b/src/CollectForm.tsx
@@ -1,5 +1,42 @@
 import React, { type ReactNode } from "react";
 
+export interface CollectDateRangeProps {
+  startDate: string;
+  endDate: string;
+  onStartChange: (value: string) => void;
+  onEndChange: (value: string) => void;
+}
+
+export function CollectDateRange({
+  startDate,
+  endDate,
+  onStartChange,
+  onEndChange,
+}: CollectDateRangeProps) {
+  return (
+    <div className="generate-collect-dates">
+      <label className="generate-collect-label">
+        From{" "}
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => onStartChange(e.target.value)}
+          className="generate-collect-date"
+        />
+      </label>
+      <label className="generate-collect-label">
+        To{" "}
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => onEndChange(e.target.value)}
+          className="generate-collect-date"
+        />
+      </label>
+    </div>
+  );
+}
+
 interface CollectFormProps {
   startDate: string;
   endDate: string;
@@ -28,26 +65,12 @@ export default function CollectForm({
   return (
     <div className="generate-collect-form">
       {children}
-      <div className="generate-collect-dates">
-        <label className="generate-collect-label">
-          From{" "}
-          <input
-            type="date"
-            value={startDate}
-            onChange={(e) => onStartChange(e.target.value)}
-            className="generate-collect-date"
-          />
-        </label>
-        <label className="generate-collect-label">
-          To{" "}
-          <input
-            type="date"
-            value={endDate}
-            onChange={(e) => onEndChange(e.target.value)}
-            className="generate-collect-date"
-          />
-        </label>
-      </div>
+      <CollectDateRange
+        startDate={startDate}
+        endDate={endDate}
+        onStartChange={onStartChange}
+        onEndChange={onEndChange}
+      />
       {error && <p className="generate-error">{error}</p>}
       {progress && <p className="generate-progress">{progress}</p>}
       <button

--- a/test/Generate.test.jsx
+++ b/test/Generate.test.jsx
@@ -35,6 +35,8 @@ describe("Generate", () => {
     expect(screen.getByPlaceholderText(/timeframe.*contributions/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /generate review/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /sign in with github/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /paste a personal access token/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /use the terminal/i })).toBeInTheDocument();
   });
 
   it("Try sample loads sample JSON into textarea", async () => {
@@ -74,6 +76,7 @@ describe("Generate", () => {
   it("Fetch my data: prompts for token when empty", async () => {
     render(<Generate />);
     await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/auth/me", expect.any(Object)));
+    fireEvent.click(screen.getByRole("tab", { name: /paste a personal access token/i }));
     fireEvent.click(screen.getByRole("button", { name: /fetch my data/i }));
     await waitFor(() => {
       expect(screen.getByText(/paste your github token above/i)).toBeInTheDocument();
@@ -91,6 +94,7 @@ describe("Generate", () => {
       .mockResolvedValueOnce(mockRes({ job_id: "j1" }, true, 202))
       .mockResolvedValueOnce(mockRes({ status: "done", result: evidence }));
     render(<Generate />);
+    fireEvent.click(screen.getByRole("tab", { name: /paste a personal access token/i }));
     const tokenInput = screen.getByPlaceholderText(/paste your github token/i);
     fireEvent.change(tokenInput, { target: { value: "ghp_test" } });
     fireEvent.click(screen.getByRole("button", { name: /fetch my data/i }));
@@ -113,6 +117,7 @@ describe("Generate", () => {
       .mockResolvedValueOnce(mockRes({}, false, 401))
       .mockResolvedValueOnce(mockRes({ error: "Invalid token" }, false));
     render(<Generate />);
+    fireEvent.click(screen.getByRole("tab", { name: /paste a personal access token/i }));
     fireEvent.change(screen.getByPlaceholderText(/paste your github token/i), { target: { value: "ghp_bad" } });
     fireEvent.click(screen.getByRole("button", { name: /fetch my data/i }));
     await waitFor(() => {
@@ -120,7 +125,7 @@ describe("Generate", () => {
     });
   });
 
-  it("when signed in shows Signed in as login and Fetch my data without token input", async () => {
+  it("when signed in shows Signed in as login and Fetch my data on first tab", async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(mockRes({ login: "alice", scope: "read:user" }))
       .mockResolvedValueOnce(mockRes({ latest: null }));
@@ -129,7 +134,7 @@ describe("Generate", () => {
       expect(screen.getByText("alice")).toBeInTheDocument();
     });
     expect(screen.getByText(/signed in as/i)).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(/paste your github token/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /fetch your data/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /fetch my data/i })).toBeInTheDocument();
   });
 });

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -131,7 +131,7 @@ describe("auth", () => {
         sessionSecret: secret,
       };
       await handleCallback(req, res, deps);
-      expect(res.writeHead).toHaveBeenCalledWith(302, { Location: "/?error=auth_failed" });
+      expect(res.writeHead).toHaveBeenCalledWith(302, { Location: "/generate?error=auth_failed" });
       expect(deps.createSession).not.toHaveBeenCalled();
     });
 
@@ -147,7 +147,7 @@ describe("auth", () => {
         sessionSecret: secret,
       };
       await handleCallback(req, res, deps);
-      expect(res.writeHead).toHaveBeenCalledWith(302, { Location: "/?error=auth_failed" });
+      expect(res.writeHead).toHaveBeenCalledWith(302, { Location: "/generate?error=auth_failed" });
     });
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -104,6 +104,8 @@ function apiRoutesPlugin() {
           getAuthRedirectUrl,
           respondJson,
           randomState,
+          log: (event, detail) =>
+            console.error("[auth]", event, detail ? String(detail) : ""),
         })
       );
 


### PR DESCRIPTION
## Summary

- **3 tabs on /generate:** Sign in with GitHub → Paste a Personal Access Token → Use the terminal.
- **Auth failure:** Redirect to `/generate?error=auth_failed` (no longer homepage); show banner with callback URL hint for local dev; Vite dev server logs failure reason.
- **Date picker:** Shown on Sign-in tab only after sign-in; PAT tab still has dates.
- **CollectDateRange** extracted from CollectForm for reuse.

Tests and build pass.