### PR TITLE
chore: tighten gitignore and dockerignore for frontend and backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Git and env
+.git
+.env
+.env.*
+*.log
+
+# Node / frontend
+node_modules
+dist
+frontend/node_modules
+frontend/dist
+frontend/coverage
+frontend/.vite
+
+# Backend (when present)
+backend/log
+backend/tmp
+backend/storage
+backend/.bundle
+backend/config/master.key

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,25 @@
+# Dependencies and build
 node_modules/
 dist/
+
+# Env and secrets
 .env
 .env.*
+!.env.example
+
+# Logs and OS
 *.log
 .DS_Store
+
+# Frontend / Node
+coverage/
+.vite/
+.turbo/
+.eslintcache
+*.tsbuildinfo
+
+# Backend (backstop; backend/.gitignore has the rest)
+backend/storage/
+backend/log/
+backend/tmp/
+backend/.bundle/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,14 @@
+# Dependencies and build
+node_modules/
+dist/
+
+# Test and tooling
+coverage/
+.vite/
+*.tsbuildinfo
+.eslintcache
+
+# Local env overrides
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
## Summary
- **Root .gitignore**: Added coverage/, .vite/, .turbo/, .eslintcache, *.tsbuildinfo; backstop entries for backend/storage, log, tmp, .bundle. Keeps !.env.example so a sample env can be committed.
- **frontend/.gitignore**: New file so the frontend folder has its own ignores (node_modules, dist, coverage, .vite, env overrides).
- **.dockerignore**: New file so Docker builds don’t copy node_modules, dist, backend log/tmp/storage, frontend coverage/.vite, or secrets.

Tests and build were run before committing (`yarn test`, `yarn build`).