### PR TITLE
feat: narrative After view for Themes, Bullets, STAR stories, Self-eval

### DIFF
--- a/src/Generate.tsx
+++ b/src/Generate.tsx
@@ -9,7 +9,7 @@ import { parseJsonResponse, pollJob } from "./api.js";
 import { useAuth } from "./hooks/useAuth";
 import { useGitHubCollect } from "./hooks/useGitHubCollect";
 import CollectForm from "./CollectForm";
-import ResultSection from "./ResultSection";
+import NarrativeView, { type NarrativeViewProps } from "./NarrativeView";
 
 const GITHUB_TOKEN_URL =
   "https://github.com/settings/tokens/new?scopes=repo&description=AnnualReview.dev";
@@ -513,13 +513,7 @@ yarn normalize --input raw.json --output evidence.json`}
         {result && (
           <div className="generate-result">
             <h2>Your review</h2>
-            <ResultSection title="Themes" data={result.themes} />
-            <ResultSection title="Bullets" data={result.bullets} />
-            <ResultSection title="STAR stories" data={result.stories} />
-            <ResultSection
-              title="Self-eval sections"
-              data={result.self_eval}
-            />
+            <NarrativeView {...(result as NarrativeViewProps)} />
             <ReportSection
               result={result}
               evidenceText={evidenceText}

--- a/src/NarrativeView.css
+++ b/src/NarrativeView.css
@@ -1,0 +1,209 @@
+.narrative-section {
+  margin-bottom: 1rem;
+}
+
+.narrative-block {
+  margin-bottom: 1.5rem;
+}
+
+.narrative-block-head {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.narrative-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.narrative-toggle {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.narrative-toggle:hover {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+.narrative-empty {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.narrative-card {
+  border-radius: 12px;
+  border: 1px solid rgba(201, 162, 39, 0.2);
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.narrative-theme {
+  padding: 1.25rem;
+}
+
+.narrative-theme + .narrative-theme {
+  border-top: 1px solid var(--border);
+}
+
+.narrative-theme-name {
+  font-weight: 700;
+  margin: 0 0 0.4rem;
+}
+
+.narrative-theme-oneliner {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  font-style: italic;
+  margin: 0 0 0.35rem;
+}
+
+.narrative-theme-why {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  margin: 0 0 0.35rem;
+}
+
+.narrative-theme-why strong {
+  font-weight: 600;
+}
+
+.narrative-theme-meta {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0 0 0.35rem;
+}
+
+.narrative-theme-evidence {
+  margin: 0.35rem 0 0;
+}
+
+.narrative-theme-evidence .evidence-tag {
+  margin-right: 0.25rem;
+}
+
+.narrative-bullet {
+  font-size: 0.85rem;
+  line-height: 1.6;
+  margin: 0 0 0.5rem;
+}
+
+.narrative-bullet:last-child {
+  margin-bottom: 0;
+}
+
+.narrative-section .evidence-tag {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  background: rgba(201, 162, 39, 0.1);
+  color: var(--accent);
+  padding: 0.1rem 0.45rem;
+  border-radius: 4px;
+  margin-left: 0.25rem;
+  vertical-align: middle;
+  text-decoration: none;
+}
+
+.narrative-section .evidence-tag:hover {
+  background: rgba(201, 162, 39, 0.2);
+}
+
+.narrative-json-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.narrative-json-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* ─── STAR stories ─── */
+.narrative-story {
+  padding: 1.25rem;
+}
+
+.narrative-story + .narrative-story {
+  border-top: 1px solid var(--border);
+}
+
+.narrative-story-title {
+  font-weight: 700;
+  font-size: 1rem;
+  margin: 0 0 0.5rem;
+}
+
+.narrative-story-field {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  margin: 0 0 0.35rem;
+}
+
+.narrative-story-field strong {
+  font-weight: 600;
+}
+
+.narrative-story-list {
+  font-size: 0.85rem;
+  margin: 0 0 0.5rem;
+}
+
+.narrative-story-list ul {
+  margin: 0.25rem 0 0 1.25rem;
+  padding: 0;
+}
+
+.narrative-story-list li {
+  margin-bottom: 0.2rem;
+}
+
+.narrative-story-evidence {
+  margin: 0.35rem 0 0;
+}
+
+/* ─── Self-eval ─── */
+.narrative-selfeval {
+  padding: 0;
+}
+
+.narrative-selfeval-section {
+  padding: 1.25rem;
+}
+
+.narrative-selfeval-section + .narrative-selfeval-section {
+  border-top: 1px solid var(--border);
+}
+
+.narrative-selfeval-heading {
+  font-weight: 700;
+  font-size: 0.95rem;
+  margin: 0 0 0.4rem;
+}
+
+.narrative-selfeval-text {
+  font-size: 0.85rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.narrative-selfeval-list {
+  margin: 0.35rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.narrative-selfeval-list li {
+  margin-bottom: 0.4rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}

--- a/src/NarrativeView.tsx
+++ b/src/NarrativeView.tsx
@@ -1,0 +1,451 @@
+import React, { useState } from "react";
+import "./NarrativeView.css";
+
+interface EvidenceRef {
+  id?: string;
+  url?: string;
+  title?: string;
+}
+
+interface Bullet {
+  text?: string;
+  evidence?: EvidenceRef[];
+}
+
+interface BulletsByTheme {
+  theme_id?: string;
+  bullets?: Bullet[];
+}
+
+interface AnchorEvidence {
+  id?: string;
+  url?: string;
+  title?: string;
+  repo?: string;
+}
+
+interface ThemeEntry {
+  theme_id?: string;
+  theme_name?: string;
+  one_liner?: string;
+  why_it_matters?: string;
+  confidence?: string;
+  notes_or_assumptions?: string;
+  anchor_evidence?: AnchorEvidence[];
+}
+
+interface ThemesPayload {
+  themes?: ThemeEntry[];
+}
+
+interface BulletsPayload {
+  bullets_by_theme?: BulletsByTheme[];
+}
+
+interface Story {
+  title?: string;
+  theme_id?: string;
+  situation?: string;
+  task?: string;
+  actions?: string[];
+  results?: string[];
+  evidence?: EvidenceRef[];
+  confidence?: string;
+}
+
+interface StoriesPayload {
+  stories?: Story[];
+}
+
+interface SelfEvalSection {
+  text?: string;
+  evidence?: EvidenceRef[];
+}
+
+interface SelfEvalSections {
+  summary?: SelfEvalSection;
+  key_accomplishments?: (Bullet & { evidence?: EvidenceRef[] })[];
+  how_i_worked?: SelfEvalSection;
+  growth?: SelfEvalSection;
+  next_year_goals?: (Bullet & { evidence?: EvidenceRef[] })[];
+}
+
+interface SelfEvalPayload {
+  sections?: SelfEvalSections;
+}
+
+export interface NarrativeViewProps {
+  themes?: ThemesPayload;
+  bullets?: BulletsPayload;
+  stories?: StoriesPayload;
+  self_eval?: SelfEvalPayload;
+}
+
+export function shortEvidenceLabel(id?: string): string {
+  if (!id) return "ref";
+  const hashIdx = id.indexOf("#");
+  if (hashIdx === -1) return id;
+  const fragment = id.slice(hashIdx + 1);
+  return /^\d+$/.test(fragment) ? `PR #${fragment}` : `#${fragment}`;
+}
+
+function JsonBlock({ data, label }: { data: unknown; label: string }) {
+  const text = JSON.stringify(data, null, 2);
+  return (
+    <div className="narrative-json">
+      <div className="narrative-json-head">
+        <span className="narrative-json-label">{label} JSON</span>
+        <button
+          type="button"
+          className="generate-copy"
+          onClick={() => navigator.clipboard.writeText(text)}
+        >
+          Copy
+        </button>
+      </div>
+      <pre className="generate-pre">{text}</pre>
+    </div>
+  );
+}
+
+function ViewToggle({
+  label,
+  showJson,
+  onToggle,
+}: {
+  label: string;
+  showJson: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button type="button" className="narrative-toggle" onClick={onToggle}>
+      {label}: show {showJson ? "Narrative" : "JSON"}
+    </button>
+  );
+}
+
+export default function NarrativeView({
+  themes,
+  bullets,
+  stories,
+  self_eval,
+}: NarrativeViewProps) {
+  const [themesJson, setThemesJson] = useState(false);
+  const [bulletsJson, setBulletsJson] = useState(false);
+  const [storiesJson, setStoriesJson] = useState(false);
+  const [selfEvalJson, setSelfEvalJson] = useState(false);
+
+  const byTheme = bullets?.bullets_by_theme ?? [];
+  const themeMap = Object.fromEntries(
+    (themes?.themes ?? []).map((t) => [t.theme_id, t.theme_name]),
+  );
+
+  return (
+    <section className="narrative-section">
+      {/* ── Themes ── */}
+      <div className="narrative-block">
+        <div className="narrative-block-head">
+          <h3 className="narrative-heading">Themes</h3>
+          {themes && (
+            <ViewToggle
+              label="Themes"
+              showJson={themesJson}
+              onToggle={() => setThemesJson((v) => !v)}
+            />
+          )}
+        </div>
+        {themesJson ? (
+          <JsonBlock data={themes} label="Themes" />
+        ) : (
+          <ThemesNarrative themeList={themes?.themes ?? []} />
+        )}
+      </div>
+
+      {/* ── Bullets ── */}
+      <div className="narrative-block">
+        <div className="narrative-block-head">
+          <h3 className="narrative-heading">Bullets</h3>
+          {bullets && (
+            <ViewToggle
+              label="Bullets"
+              showJson={bulletsJson}
+              onToggle={() => setBulletsJson((v) => !v)}
+            />
+          )}
+        </div>
+        {bulletsJson ? (
+          <JsonBlock data={bullets} label="Bullets" />
+        ) : (
+          <BulletsNarrative themeMap={themeMap} byTheme={byTheme} />
+        )}
+      </div>
+
+      {/* ── STAR stories ── */}
+      <div className="narrative-block">
+        <div className="narrative-block-head">
+          <h3 className="narrative-heading">STAR stories</h3>
+          {stories && (
+            <ViewToggle
+              label="STAR stories"
+              showJson={storiesJson}
+              onToggle={() => setStoriesJson((v) => !v)}
+            />
+          )}
+        </div>
+        {storiesJson ? (
+          <JsonBlock data={stories} label="STAR stories" />
+        ) : (
+          <StoriesNarrative storyList={stories?.stories ?? []} />
+        )}
+      </div>
+
+      {/* ── Self-eval ── */}
+      <div className="narrative-block">
+        <div className="narrative-block-head">
+          <h3 className="narrative-heading">Self-eval sections</h3>
+          {self_eval && (
+            <ViewToggle
+              label="Self-eval"
+              showJson={selfEvalJson}
+              onToggle={() => setSelfEvalJson((v) => !v)}
+            />
+          )}
+        </div>
+        {selfEvalJson ? (
+          <JsonBlock data={self_eval} label="Self-eval" />
+        ) : (
+          <SelfEvalNarrative sections={self_eval?.sections} />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ThemesNarrative({ themeList }: { themeList: ThemeEntry[] }) {
+  if (themeList.length === 0) {
+    return <p className="narrative-empty">No themes yet.</p>;
+  }
+  return (
+    <div className="narrative-card">
+      {themeList.map((t) => (
+        <div key={t.theme_id ?? t.theme_name ?? "unknown"} className="narrative-theme">
+          <p className="narrative-theme-name">{t.theme_name ?? t.theme_id}</p>
+          {t.one_liner && (
+            <p className="narrative-theme-oneliner">{t.one_liner}</p>
+          )}
+          {t.why_it_matters && (
+            <p className="narrative-theme-why">
+              <strong>Why it matters:</strong> {t.why_it_matters}
+            </p>
+          )}
+          {(t.confidence || t.notes_or_assumptions) && (
+            <p className="narrative-theme-meta">
+              {t.confidence && <span>Confidence: {t.confidence}</span>}
+              {t.confidence && t.notes_or_assumptions && " · "}
+              {t.notes_or_assumptions && (
+                <span className="narrative-meta-notes">{t.notes_or_assumptions}</span>
+              )}
+            </p>
+          )}
+          {(t.anchor_evidence?.length ?? 0) > 0 && (
+            <p className="narrative-theme-evidence">
+              {(t.anchor_evidence ?? []).map((e) => (
+                <a
+                  key={e.id ?? e.url}
+                  href={e.url}
+                  className="evidence-tag"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {e.title ?? shortEvidenceLabel(e.id)}
+                </a>
+              ))}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BulletsNarrative({
+  themeMap,
+  byTheme,
+}: {
+  themeMap: Record<string, string | undefined>;
+  byTheme: BulletsByTheme[];
+}) {
+  if (byTheme.length === 0) {
+    return <p className="narrative-empty">No impact bullets by theme yet.</p>;
+  }
+  return (
+    <div className="narrative-card">
+      {byTheme.map((group) => (
+        <div key={group.theme_id ?? "unknown"} className="narrative-theme">
+          <p className="narrative-theme-name">
+            {themeMap[group.theme_id ?? ""] ?? group.theme_id}
+          </p>
+          {(group.bullets ?? []).map((b, i) => (
+            <p key={i} className="narrative-bullet">
+              {b.text}
+              {(b.evidence ?? []).map((e) => (
+                <a
+                  key={e.id ?? e.url}
+                  href={e.url}
+                  className="evidence-tag"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {shortEvidenceLabel(e.id)}
+                </a>
+              ))}
+            </p>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EvidenceTags({ evidence }: { evidence?: EvidenceRef[] }) {
+  if (!evidence?.length) return null;
+  return (
+    <span className="narrative-theme-evidence">
+      {(evidence ?? []).map((e) => (
+        <a
+          key={e.id ?? e.url}
+          href={e.url}
+          className="evidence-tag"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {e.title ?? shortEvidenceLabel(e.id)}
+        </a>
+      ))}
+    </span>
+  );
+}
+
+function StoriesNarrative({ storyList }: { storyList: Story[] }) {
+  if (storyList.length === 0) {
+    return <p className="narrative-empty">No STAR stories yet.</p>;
+  }
+  return (
+    <div className="narrative-card">
+      {storyList.map((s, idx) => (
+        <div key={s.title ?? idx} className="narrative-story">
+          <p className="narrative-story-title">{s.title}</p>
+          {s.situation && (
+            <p className="narrative-story-field">
+              <strong>Situation:</strong> {s.situation}
+            </p>
+          )}
+          {s.task && (
+            <p className="narrative-story-field">
+              <strong>Task:</strong> {s.task}
+            </p>
+          )}
+          {(s.actions?.length ?? 0) > 0 && (
+            <div className="narrative-story-list">
+              <strong>Actions:</strong>
+              <ul>
+                {(s.actions ?? []).map((a, i) => (
+                  <li key={i}>{a}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {(s.results?.length ?? 0) > 0 && (
+            <div className="narrative-story-list">
+              <strong>Results:</strong>
+              <ul>
+                {(s.results ?? []).map((r, i) => (
+                  <li key={i}>{r}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {(s.evidence?.length ?? 0) > 0 && (
+            <p className="narrative-story-evidence">
+              <EvidenceTags evidence={s.evidence} />
+            </p>
+          )}
+          {s.confidence && (
+            <p className="narrative-theme-meta">Confidence: {s.confidence}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SelfEvalNarrative({
+  sections,
+}: {
+  sections?: SelfEvalSections;
+}) {
+  if (!sections) {
+    return <p className="narrative-empty">No self-eval sections yet.</p>;
+  }
+  const hasAny =
+    sections.summary?.text ||
+    (sections.key_accomplishments?.length ?? 0) > 0 ||
+    sections.how_i_worked?.text ||
+    sections.growth?.text ||
+    (sections.next_year_goals?.length ?? 0) > 0;
+  if (!hasAny) {
+    return <p className="narrative-empty">No self-eval sections yet.</p>;
+  }
+
+  return (
+    <div className="narrative-card narrative-selfeval">
+      {sections.summary?.text && (
+        <div className="narrative-selfeval-section">
+          <p className="narrative-selfeval-heading">Summary</p>
+          <p className="narrative-selfeval-text">{sections.summary.text}</p>
+          <EvidenceTags evidence={sections.summary.evidence} />
+        </div>
+      )}
+      {(sections.key_accomplishments?.length ?? 0) > 0 && (
+        <div className="narrative-selfeval-section">
+          <p className="narrative-selfeval-heading">Key accomplishments</p>
+          <ul className="narrative-selfeval-list">
+            {(sections.key_accomplishments ?? []).map((item, i) => (
+              <li key={i} className="narrative-bullet">
+                {item.text}
+                <EvidenceTags evidence={item.evidence} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {sections.how_i_worked?.text && (
+        <div className="narrative-selfeval-section">
+          <p className="narrative-selfeval-heading">How I worked</p>
+          <p className="narrative-selfeval-text">{sections.how_i_worked.text}</p>
+          <EvidenceTags evidence={sections.how_i_worked.evidence} />
+        </div>
+      )}
+      {sections.growth?.text && (
+        <div className="narrative-selfeval-section">
+          <p className="narrative-selfeval-heading">Growth</p>
+          <p className="narrative-selfeval-text">{sections.growth.text}</p>
+          <EvidenceTags evidence={sections.growth.evidence} />
+        </div>
+      )}
+      {(sections.next_year_goals?.length ?? 0) > 0 && (
+        <div className="narrative-selfeval-section">
+          <p className="narrative-selfeval-heading">Next year goals</p>
+          <ul className="narrative-selfeval-list">
+            {(sections.next_year_goals ?? []).map((g, i) => (
+              <li key={i} className="narrative-bullet">
+                {g.text}
+                <EvidenceTags evidence={g.evidence} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/test/NarrativeView.test.jsx
+++ b/test/NarrativeView.test.jsx
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import NarrativeView, { shortEvidenceLabel } from "../src/NarrativeView.tsx";
+
+const mockThemes = {
+  themes: [
+    { theme_id: "reliability", theme_name: "Platform Reliability" },
+    { theme_id: "arch", theme_name: "Architecture" },
+  ],
+};
+
+const mockBullets = {
+  bullets_by_theme: [
+    {
+      theme_id: "reliability",
+      bullets: [
+        {
+          text: "Improved webhook delivery success rate by adding retry logic.",
+          evidence: [
+            { id: "org/repo#412", url: "https://github.com/org/repo/pull/412" },
+          ],
+        },
+      ],
+    },
+    {
+      theme_id: "arch",
+      bullets: [
+        {
+          text: "Led extraction of billing service from the monolith.",
+          evidence: [
+            { id: "org/repo#389", url: "https://github.com/org/repo/pull/389" },
+            { id: "org/repo#401", url: "https://github.com/org/repo/pull/401" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("shortEvidenceLabel", () => {
+  it("extracts PR number from org/repo#123", () => {
+    expect(shortEvidenceLabel("org/repo#412")).toBe("PR #412");
+  });
+
+  it("returns raw id when no # present", () => {
+    expect(shortEvidenceLabel("some-id")).toBe("some-id");
+  });
+
+  it("returns hash suffix as-is for non-numeric fragments", () => {
+    expect(shortEvidenceLabel("org/repo#abc")).toBe("#abc");
+  });
+
+  it("handles undefined/empty gracefully", () => {
+    expect(shortEvidenceLabel(undefined)).toBe("ref");
+    expect(shortEvidenceLabel("")).toBe("ref");
+  });
+});
+
+describe("NarrativeView", () => {
+  it("renders theme names as headings", () => {
+    render(<NarrativeView themes={mockThemes} bullets={mockBullets} />);
+    expect(screen.getAllByText("Platform Reliability").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Architecture").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders bullet text", () => {
+    render(<NarrativeView themes={mockThemes} bullets={mockBullets} />);
+    expect(screen.getByText(/Improved webhook delivery/)).toBeInTheDocument();
+    expect(screen.getByText(/Led extraction of billing/)).toBeInTheDocument();
+  });
+
+  it("renders evidence tags as links with short labels", () => {
+    render(<NarrativeView themes={mockThemes} bullets={mockBullets} />);
+    const link412 = screen.getByRole("link", { name: "PR #412" });
+    expect(link412).toHaveAttribute("href", "https://github.com/org/repo/pull/412");
+
+    const link389 = screen.getByRole("link", { name: "PR #389" });
+    expect(link389).toHaveAttribute("href", "https://github.com/org/repo/pull/389");
+  });
+
+  it("falls back to theme_id when theme name not found", () => {
+    const bullets = {
+      bullets_by_theme: [
+        {
+          theme_id: "unknown-theme",
+          bullets: [{ text: "Some bullet.", evidence: [] }],
+        },
+      ],
+    };
+    render(<NarrativeView themes={mockThemes} bullets={bullets} />);
+    expect(screen.getAllByText("unknown-theme").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows empty state when bullets_by_theme is empty", () => {
+    render(<NarrativeView themes={mockThemes} bullets={{ bullets_by_theme: [] }} />);
+    expect(screen.getByText(/no impact bullets/i)).toBeInTheDocument();
+  });
+
+  it("shows empty state when bullets prop is undefined", () => {
+    render(<NarrativeView themes={mockThemes} bullets={undefined} />);
+    expect(screen.getByText(/no impact bullets/i)).toBeInTheDocument();
+  });
+
+  it("shows empty state when themes and bullets are both undefined", () => {
+    render(<NarrativeView themes={undefined} bullets={undefined} />);
+    expect(screen.getByText(/no impact bullets/i)).toBeInTheDocument();
+  });
+
+  // ── Toggle behavior ──
+
+  it("defaults to narrative view, not JSON", () => {
+    render(<NarrativeView themes={mockThemes} bullets={mockBullets} />);
+    expect(screen.getAllByText("Platform Reliability").length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText(/"theme_id"/)).not.toBeInTheDocument();
+  });
+
+  it("toggles Themes to JSON view and back", () => {
+    render(<NarrativeView themes={mockThemes} bullets={mockBullets} />);
+    const themesToggle = screen.getByRole("button", { name: /themes.*json/i });
+    fireEvent.click(themesToggle);
+    expect(screen.getByText(/"theme_id"/)).toBeInTheDocument();
+    expect(screen.getByText(/"Platform Reliability"/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /themes.*narrative/i }));
+    expect(screen.queryByText(/"theme_id"/)).not.toBeInTheDocument();
+    expect(screen.getAllByText("Platform Reliability").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("toggles Bullets to JSON view and back", () => {
+    render(<NarrativeView themes={mockThemes} bullets={mockBullets} />);
+    const bulletsToggle = screen.getByRole("button", { name: /bullets.*json/i });
+    fireEvent.click(bulletsToggle);
+    expect(screen.getByText(/"bullets_by_theme"/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /bullets.*narrative/i }));
+    expect(screen.queryByText(/"bullets_by_theme"/)).not.toBeInTheDocument();
+  });
+
+  it("shows copy button in JSON view for Themes", () => {
+    render(<NarrativeView themes={mockThemes} bullets={mockBullets} />);
+    fireEvent.click(screen.getByRole("button", { name: /themes.*json/i }));
+    const copyButtons = screen.getAllByRole("button", { name: /copy/i });
+    expect(copyButtons.length).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
- **Narrative view** on the Generate page for all four pipeline outputs (Themes, Bullets, STAR stories, Self-eval), matching the "After" style from the homepage.
- Each section **toggles** between the narrative view and raw JSON (with Copy).

## Changes
- **NarrativeView** component with four blocks:
  - **Themes**: theme name, one-liner, why it matters, confidence, notes, anchor evidence tags
  - **Bullets**: impact bullets by theme with evidence tags (PR #123 style)
  - **STAR stories**: title, Situation, Task, Actions, Results, evidence tags, confidence
  - **Self-eval**: Summary, Key accomplishments, How I worked, Growth, Next year goals (each with evidence tags when present)
- Removed separate `ResultSection` usage for STAR stories and self-eval; NarrativeView now receives `themes`, `bullets`, `stories`, `self_eval`.
- Tests: `test/NarrativeView.test.jsx` (15 tests) for narrative rendering, empty states, and JSON toggle.
- Exported `NarrativeViewProps` for type-safe usage in Generate.

## Verification
- `yarn test`: 120 tests pass
- `yarn build`: succeeds
- Typecheck: `Generate.tsx` NarrativeView props fixed; pre-existing typecheck errors remain in `lib/run-pipeline.ts` and server routes.