### PR TITLE
Require SESSION_SECRET in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The repo ships with `nixpacks.toml` for one-click Coolify deploys. See [docs/dep
 
 | Variable | Description |
 |----------|-------------|
-| `SESSION_SECRET` | Random string for signing session cookies (e.g. `openssl rand -hex 32`) |
+| `SESSION_SECRET` | **Required in production.** Random string for signing session cookies (e.g. `openssl rand -hex 32`). In local dev, the server falls back to a built-in `"dev-secret"` when unset. |
 | `GITHUB_CLIENT_ID` | From your [GitHub OAuth App](https://github.com/settings/developers) |
 | `GITHUB_CLIENT_SECRET` | From the same OAuth App |
 | `OPENROUTER_API_KEY` | LLM provider for the generate pipeline — free tier defaults to `anthropic/claude-3-haiku`, premium to `anthropic/claude-haiku-4.5`. |

--- a/docs/deploy-coolify.md
+++ b/docs/deploy-coolify.md
@@ -8,7 +8,7 @@ The repo includes `nixpacks.toml` so Nixpacks runs `yarn build` and then `yarn s
    - Server listens on `PORT` (Coolify sets this automatically).
 
 2. **Environment variables** (set in Coolify → your service → Environment)
-   - `SESSION_SECRET` — random string for signing session cookies (e.g. `openssl rand -hex 32`)
+   - `SESSION_SECRET` — **required in production**; random string for signing session cookies (e.g. `openssl rand -hex 32`)
    - `GITHUB_CLIENT_ID` — from [GitHub OAuth App](https://github.com/settings/developers)
    - `GITHUB_CLIENT_SECRET` — from the same OAuth App
    - `OPENROUTER_API_KEY` — **required** for the generate pipeline. Uses OpenRouter with Claude (free: Haiku, premium: Sonnet).

--- a/server.ts
+++ b/server.ts
@@ -50,18 +50,14 @@ import {
   getStateFromRequest,
   clearStateCookie,
 } from "./lib/cookies.ts";
-import {
-  readJsonBody,
-  respondJson,
-  randomState,
-  DATE_YYYY_MM_DD,
-} from "./server/helpers.ts";
+import { readJsonBody, respondJson, randomState, DATE_YYYY_MM_DD } from "./server/helpers.ts";
 import { authRoutes } from "./server/routes/auth.ts";
 import { jobsRoutes } from "./server/routes/jobs.ts";
 import { generateRoutes } from "./server/routes/generate.ts";
 import { collectRoutes } from "./server/routes/collect.ts";
 import { logger } from "./lib/posthog-logs.ts";
 import { paymentsRoutes } from "./server/routes/payments.ts";
+import { getSessionSecret } from "./server/session-secret.ts";
 
 const MIME: Record<string, string> = {
   ".html": "text/html",
@@ -113,7 +109,7 @@ function handleRequest(
   const [pathname, queryString] = url.split("?");
   const path = pathname.replace(/^\/+/, "");
 
-  const sessionSecret = process.env.SESSION_SECRET || "dev-secret";
+  const sessionSecret = getSessionSecret();
   const clientId = process.env.GITHUB_CLIENT_ID;
   const clientSecret = process.env.GITHUB_CLIENT_SECRET;
   const isSecure = req.headers["x-forwarded-proto"] === "https";

--- a/server/session-secret.ts
+++ b/server/session-secret.ts
@@ -1,0 +1,13 @@
+const isDev = process.env.NODE_ENV !== "production";
+
+export function getSessionSecret(): string {
+  const sessionSecret =
+    process.env.SESSION_SECRET || (isDev ? "dev-secret" : "");
+
+  if (!sessionSecret) {
+    throw new Error("SESSION_SECRET must be set in production");
+  }
+
+  return sessionSecret;
+}
+

--- a/test/session-secret.test.ts
+++ b/test/session-secret.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("getSessionSecret", () => {
+  it("falls back to dev-secret in non-production when SESSION_SECRET is missing", async () => {
+    delete process.env.SESSION_SECRET;
+    process.env.NODE_ENV = "development";
+
+    const { getSessionSecret } = await import("../server/session-secret.ts");
+
+    expect(getSessionSecret()).toBe("dev-secret");
+  });
+
+  it("requires SESSION_SECRET in production", async () => {
+    delete process.env.SESSION_SECRET;
+    process.env.NODE_ENV = "production";
+
+    const { getSessionSecret } = await import("../server/session-secret.ts");
+
+    expect(() => getSessionSecret()).toThrowError(
+      "SESSION_SECRET must be set in production",
+    );
+  });
+});
+


### PR DESCRIPTION
Closes #75.

**Changes**
- **server/session-secret.ts**: `getSessionSecret()` — in dev uses `SESSION_SECRET || 'dev-secret'`; in production throws if `SESSION_SECRET` is unset.
- **server.ts**: Uses `getSessionSecret()` so the app refuses to start when `NODE_ENV === 'production'` and `SESSION_SECRET` is missing.
- **test/session-secret.test.ts**: Tests dev fallback and production fail-fast.
- **README.md** and **docs/deploy-coolify.md**: Document that `SESSION_SECRET` is required in production.

**Verification**
- `yarn test run`, `yarn typecheck`, `yarn build` all pass.