### PR TITLE
Return 503 PAYMENTS_NOT_CONFIGURED instead of 500 when DB absent for premium

### DIFF
--- a/lib/api-error-codes.ts
+++ b/lib/api-error-codes.ts
@@ -1,0 +1,4 @@
+/** Shared API error code constants used by both server routes and frontend clients. */
+
+/** Returned (HTTP 503) when a premium request is made but the credit store (DATABASE_URL) is not configured. */
+export const PAYMENTS_NOT_CONFIGURED = "PAYMENTS_NOT_CONFIGURED" as const;

--- a/lib/payment-store.ts
+++ b/lib/payment-store.ts
@@ -104,8 +104,19 @@ export async function deductCredit(userLogin: string): Promise<boolean> {
 }
 
 /** Returns true when a Postgres DATABASE_URL is configured and the credit store can be used. */
-export function isPaymentsConfigured(): boolean {
+export function isCreditStoreConfigured(): boolean {
   return !!process.env.DATABASE_URL;
+}
+
+/**
+ * @deprecated Use {@link isCreditStoreConfigured} instead.
+ *
+ * This only checks that the Postgres-backed credit store is configured
+ * (via DATABASE_URL). It does not validate Stripe or any other payments
+ * configuration.
+ */
+export function isPaymentsConfigured(): boolean {
+  return isCreditStoreConfigured();
 }
 
 /** Reset the store (for tests). Clears all rows. */

--- a/server/routes/generate.ts
+++ b/server/routes/generate.ts
@@ -16,7 +16,8 @@ import type { ValidationResult } from "../../lib/validate-evidence.js";
 import type { Evidence } from "../../types/evidence.js";
 import type { PipelineResult } from "../../lib/run-pipeline.js";
 import type { SessionData } from "../../lib/session-store.js";
-import { awardCredits, deductCredit, getCredits, isPaymentsConfigured as defaultIsPaymentsConfigured } from "../../lib/payment-store.js";
+import { awardCredits, deductCredit, getCredits, isCreditStoreConfigured as defaultIsPaymentsConfigured } from "../../lib/payment-store.js";
+import { PAYMENTS_NOT_CONFIGURED } from "../../lib/api-error-codes.js";
 import Stripe from "stripe";
 import { STRIPE_API_VERSION } from "../config.js";
 
@@ -127,7 +128,7 @@ export function generateRoutes(options: GenerateRoutesOptions) {
 
       if (wantsPremium) {
         if (!isPaymentsConfigured()) {
-          respondJson(res, 503, { error: "Premium is not available", code: "PAYMENTS_NOT_CONFIGURED" });
+          respondJson(res, 503, { error: "Premium is not available", code: PAYMENTS_NOT_CONFIGURED });
           return;
         }
         // Must be logged in — credits are tied to a GitHub account

--- a/src/Generate.tsx
+++ b/src/Generate.tsx
@@ -10,6 +10,7 @@ import { useAuth } from "./hooks/useAuth";
 import { useGitHubCollect } from "./hooks/useGitHubCollect";
 import CollectForm from "./CollectForm";
 import NarrativeView, { type NarrativeViewProps } from "./NarrativeView";
+import { PAYMENTS_NOT_CONFIGURED } from "../lib/api-error-codes.js";
 
 /** Milliseconds to wait for React state to settle before auto-generating after Stripe redirect. */
 const STRIPE_RETURN_DELAY_MS = 100;
@@ -203,7 +204,7 @@ export default function Generate() {
         }
         posthog?.capture("review_generate_completed", { premium: !!data.premium });
       } else if (!res.ok) {
-        if ((data as { code?: string }).code === "PAYMENTS_NOT_CONFIGURED") {
+        if ((data as { code?: string }).code === PAYMENTS_NOT_CONFIGURED) {
           throw new Error("Premium generation is not available in this environment. Please use the free tier.");
         }
         throw new Error((data.error as string) || "Generate failed");

--- a/test/Generate.test.jsx
+++ b/test/Generate.test.jsx
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import Generate from "../src/Generate.tsx";
 import { pollJob } from "../src/api.js";
+import { PAYMENTS_NOT_CONFIGURED } from "../lib/api-error-codes.ts";
 
 /** Response-like mock: component uses res.text() or res.json() depending on route. */
 function mockRes(body, ok = true, status = ok ? 200 : 400) {
@@ -151,7 +152,7 @@ describe("Generate", () => {
       if (String(url) === "/api/payments/config") return Promise.resolve(mockRes({ enabled: false }));
       if (String(url) === "/api/generate")
         return Promise.resolve(
-          mockRes({ error: "Premium is not available", code: "PAYMENTS_NOT_CONFIGURED" }, false, 503)
+          mockRes({ error: "Premium is not available", code: PAYMENTS_NOT_CONFIGURED }, false, 503)
         );
       return Promise.reject(new Error("Unmocked: " + url));
     });

--- a/test/generate-premium.test.js
+++ b/test/generate-premium.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { generateRoutes } from "../server/routes/generate.ts";
 import { clearCreditStore, awardCredits, getCredits } from "../lib/payment-store.ts";
+import { PAYMENTS_NOT_CONFIGURED } from "../lib/api-error-codes.ts";
 import { mockRes, respondJson } from "./helpers.js";
 
 const hasDb = !!process.env.DATABASE_URL;
@@ -48,7 +49,7 @@ describe("generateRoutes – payments not configured", () => {
     const res = mockRes();
     await handler({ method: "POST", url: "/" }, res, () => {});
     expect(res.statusCode).toBe(503);
-    expect(res.body).toMatchObject({ error: "Premium is not available", code: "PAYMENTS_NOT_CONFIGURED" });
+    expect(res.body).toMatchObject({ error: "Premium is not available", code: PAYMENTS_NOT_CONFIGURED });
     expect(opts.runPipeline).not.toHaveBeenCalled();
   });
 
@@ -61,7 +62,7 @@ describe("generateRoutes – payments not configured", () => {
     const res = mockRes();
     await handler({ method: "POST", url: "/" }, res, () => {});
     expect(res.statusCode).toBe(503);
-    expect(res.body).toMatchObject({ error: "Premium is not available", code: "PAYMENTS_NOT_CONFIGURED" });
+    expect(res.body).toMatchObject({ error: "Premium is not available", code: PAYMENTS_NOT_CONFIGURED });
     expect(opts.runPipeline).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #79

## Problem
When `DATABASE_URL` is not set and a client requests premium generation (`_premium: true` or `_stripe_session_id`), `lib/payment-store.ts` throws `"DATABASE_URL is required for the credit store"`, which bubbles up as a generic 500.

## Changes

**`lib/payment-store.ts`**
- Added `isPaymentsConfigured(): boolean` — returns `true` when `DATABASE_URL` is set.

**`server/routes/generate.ts`**
- Added injectable `isPaymentsConfigured?: () => boolean` option (defaults to the above).
- Early guard at the top of the `wantsPremium` block: responds **HTTP 503** with `{ error: "Premium is not available", code: "PAYMENTS_NOT_CONFIGURED" }` before any DB call is attempted.

**`src/Generate.tsx`**
- When the response carries `code === "PAYMENTS_NOT_CONFIGURED"`, surfaces a specific user-facing message instead of the generic pipeline failure.

## Tests
- `test/generate-premium.test.js`: new `describe` block (not gated by `hasDb`) covering both `_premium: true` and `_stripe_session_id` paths.
- `test/Generate.test.jsx`: new test asserting the specific frontend message appears on a 503 PAYMENTS_NOT_CONFIGURED response.

`yarn test` (157 ✅) · `yarn typecheck` ✅