### PR TITLE
fix: shared loading state and progress bar for generate (fixes #104)

### DIFF
--- a/src/Generate.css
+++ b/src/Generate.css
@@ -444,6 +444,36 @@
   color: var(--text-muted);
 }
 
+.generate-actions-progress {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.generate-progress-bar {
+  height: 8px;
+  width: 100%;
+  background: var(--accent-dim);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.generate-progress-bar::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  border-radius: 4px;
+  animation: generate-progress-indeterminate 1.2s ease-in-out infinite;
+}
+
+@keyframes generate-progress-indeterminate {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(350%); }
+}
+
 .generate-btn {
   padding: 0.75rem 1.5rem;
   min-height: 2.75rem;

--- a/src/Generate.tsx
+++ b/src/Generate.tsx
@@ -648,52 +648,60 @@ yarn normalize --input raw.json --output evidence.json`}
         </div>
 
         {error && <p className="generate-error">{error}</p>}
-        {progress && <p className="generate-progress">{progress}</p>}
 
-        <div className="generate-actions">
-          <div className="generate-actions-buttons">
-            <button
-              type="button"
-              className="generate-btn"
-              onClick={() => handleGenerate()}
-              disabled={loading}
-            >
-              <span className="generate-btn-inner">
-                <span>{loading ? "Generating…" : paymentsEnabled ? "3. Generate review (free)" : "3. Generate review"}</span>
-                {!loading && freeModel && <span className="generate-btn-model">{formatModelName(freeModel)}</span>}
-              </span>
-            </button>
-            {paymentsEnabled && (
-              premiumCredits !== null && premiumCredits > 0 ? (
-                <button
-                  type="button"
-                  className="generate-btn generate-btn-premium"
-                  onClick={handleUsePremiumCredit}
-                  disabled={loading}
-                  title={`Uses ${premiumModel ? formatModelName(premiumModel) : "premium"} model`}
-                >
-                  <span className="generate-btn-inner">
-                    <span>✦ Generate premium report</span>
-                    {premiumModel && <span className="generate-btn-model">{formatModelName(premiumModel)}</span>}
-                    <span className="generate-btn-credits">{premiumCredits} credit{premiumCredits !== 1 ? "s" : ""} left</span>
-                  </span>
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  className="generate-btn generate-btn-premium"
-                  onClick={handleUpgradeToPremium}
-                  disabled={loading}
-                  title={`${creditsPerPurchase} credits for $${(priceCents / 100).toFixed(2)} (1 run = 1 credit). Uses ${premiumModel ? formatModelName(premiumModel) : "premium"} model.`}
-                >
-                  <span className="generate-btn-inner">
-                    <span>✦ Upgrade to premium — {creditsPerPurchase} credits for ${(priceCents / 100).toFixed(2)}</span>
-                    {premiumModel && <span className="generate-btn-model">{formatModelName(premiumModel)}</span>}
-                  </span>
-                </button>
-              )
-            )}
-          </div>
+        <div className="generate-actions" aria-busy={loading}>
+          {loading ? (
+            <div className="generate-actions-progress">
+              <div
+                className="generate-progress-bar"
+                role="progressbar"
+                aria-label="Generating review"
+                aria-valuetext={progress || undefined}
+              />
+              {progress && <p className="generate-progress">{progress}</p>}
+            </div>
+          ) : (
+            <div className="generate-actions-buttons">
+              <button
+                type="button"
+                className="generate-btn"
+                onClick={() => handleGenerate()}
+              >
+                <span className="generate-btn-inner">
+                  <span>{paymentsEnabled ? "3. Generate review (free)" : "3. Generate review"}</span>
+                  {freeModel && <span className="generate-btn-model">{formatModelName(freeModel)}</span>}
+                </span>
+              </button>
+              {paymentsEnabled && (
+                premiumCredits !== null && premiumCredits > 0 ? (
+                  <button
+                    type="button"
+                    className="generate-btn generate-btn-premium"
+                    onClick={handleUsePremiumCredit}
+                    title={`Uses ${premiumModel ? formatModelName(premiumModel) : "premium"} model`}
+                  >
+                    <span className="generate-btn-inner">
+                      <span>✦ Generate premium report</span>
+                      {premiumModel && <span className="generate-btn-model">{formatModelName(premiumModel)}</span>}
+                      <span className="generate-btn-credits">{premiumCredits} credit{premiumCredits !== 1 ? "s" : ""} left</span>
+                    </span>
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="generate-btn generate-btn-premium"
+                    onClick={handleUpgradeToPremium}
+                    title={`${creditsPerPurchase} credits for $${(priceCents / 100).toFixed(2)} (1 run = 1 credit). Uses ${premiumModel ? formatModelName(premiumModel) : "premium"} model.`}
+                  >
+                    <span className="generate-btn-inner">
+                      <span>✦ Upgrade to premium — {creditsPerPurchase} credits for ${(priceCents / 100).toFixed(2)}</span>
+                      {premiumModel && <span className="generate-btn-model">{formatModelName(premiumModel)}</span>}
+                    </span>
+                  </button>
+                )
+              )}
+            </div>
+          )}
         </div>
 
         {result && (

--- a/test/Generate.test.jsx
+++ b/test/Generate.test.jsx
@@ -431,6 +431,39 @@ describe("Generate", () => {
     expect(screen.queryByRole("button", { name: /premium/i })).not.toBeInTheDocument();
     jobResolve({ status: "done", result: { themes: { themes: [] }, bullets: {}, stories: {}, self_eval: {} } });
   });
+
+  it("when generating with no progress text yet, shows progressbar but no progress paragraph", async () => {
+    let jobResolve;
+    const jobHang = new Promise((r) => { jobResolve = r; });
+    let jobCalls = 0;
+    vi.mocked(fetch).mockImplementation((url) => {
+      if (String(url) === "/api/auth/me") return Promise.resolve(mockRes({}, false, 401));
+      if (String(url) === "/api/payments/config") return Promise.resolve(mockRes({ enabled: false }));
+      if (String(url) === "/api/generate") return Promise.resolve(mockRes({ job_id: "j1" }, true, 202));
+      if (String(url).includes("/api/jobs/")) {
+        jobCalls++;
+        return jobCalls === 1
+          ? Promise.resolve(mockRes({ status: "running" }))
+          : jobHang;
+      }
+      return Promise.reject(new Error("Unmocked: " + url));
+    });
+    const { container } = render(<Generate />);
+    fireEvent.change(screen.getByPlaceholderText(/timeframe.*contributions/), {
+      target: {
+        value: JSON.stringify({
+          timeframe: { start_date: "2025-01-01", end_date: "2025-12-31" },
+          contributions: [],
+        }),
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /generate review/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("progressbar", { name: /generating review/i })).toBeInTheDocument();
+    });
+    expect(container.querySelector(".generate-progress")).toBeNull();
+    jobResolve({ status: "done", result: { themes: { themes: [] }, bullets: {}, stories: {}, self_eval: {} } });
+  });
 });
 
 describe("pollJob", () => {

--- a/test/Generate.test.jsx
+++ b/test/Generate.test.jsx
@@ -432,6 +432,37 @@ describe("Generate", () => {
     jobResolve({ status: "done", result: { themes: { themes: [] }, bullets: {}, stories: {}, self_eval: {} } });
   });
 
+  it("Generate premium report button uses credit and shows shared progress UI", async () => {
+    const evidence = JSON.stringify({
+      timeframe: { start_date: "2025-01-01", end_date: "2025-12-31" },
+      contributions: [],
+    });
+    vi.mocked(fetch).mockImplementation((url) => {
+      if (String(url) === "/api/auth/me") return Promise.resolve(mockRes({ login: "u", scope: "read:user" }));
+      if (String(url) === "/api/payments/config") return Promise.resolve(mockRes({ enabled: true, credits_per_purchase: 1, price_cents: 100 }));
+      if (String(url) === "/api/payments/credits") return Promise.resolve(mockRes({ credits: 2 }));
+      if (String(url) === "/api/jobs") return Promise.resolve(mockRes({ latest: null }));
+      if (String(url) === "/api/generate") return Promise.resolve(mockRes({ job_id: "j1", premium: true, credits_remaining: 1 }, true, 202));
+      if (String(url).includes("/api/jobs/")) return Promise.resolve(mockRes({ status: "done", result: { themes: { themes: [] }, bullets: {}, stories: {}, self_eval: {} } }));
+      return Promise.reject(new Error("Unmocked: " + url));
+    });
+    const storage = {};
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation((key) => storage[key] ?? null);
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation((key, value) => { storage[key] = value; });
+    storage.premium_stripe_session_id = "sess_fake";
+    render(<Generate />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /generate premium report/i })).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText(/timeframe.*contributions/), { target: { value: evidence } });
+    fireEvent.click(screen.getByRole("button", { name: /generate premium report/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("progressbar", { name: /generating review/i })).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /your review/i })).toBeInTheDocument();
+    });
+    expect(screen.getByText(/1 credit left/i)).toBeInTheDocument();
+  });
+
   it("when generating with no progress text yet, shows progressbar but no progress paragraph", async () => {
     let jobResolve;
     const jobHang = new Promise((r) => { jobResolve = r; });

--- a/test/Generate.test.jsx
+++ b/test/Generate.test.jsx
@@ -396,6 +396,41 @@ describe("Generate", () => {
       expect(screen.getByText(/GPT 4o Mini/i)).toBeInTheDocument();
     });
   });
+
+  it("when generating, shows progress UI and hides both generate buttons", async () => {
+    let jobResolve;
+    const jobHang = new Promise((r) => { jobResolve = r; });
+    let jobCalls = 0;
+    vi.mocked(fetch).mockImplementation((url) => {
+      if (String(url) === "/api/auth/me") return Promise.resolve(mockRes({}, false, 401));
+      if (String(url) === "/api/payments/config") return Promise.resolve(mockRes({ enabled: false }));
+      if (String(url) === "/api/generate") return Promise.resolve(mockRes({ job_id: "j1" }, true, 202));
+      if (String(url).includes("/api/jobs/")) {
+        jobCalls++;
+        return jobCalls === 1
+          ? Promise.resolve(mockRes({ status: "running", progress: "1/5 Themes" }))
+          : jobHang;
+      }
+      return Promise.reject(new Error("Unmocked: " + url));
+    });
+    render(<Generate />);
+    fireEvent.change(screen.getByPlaceholderText(/timeframe.*contributions/), {
+      target: {
+        value: JSON.stringify({
+          timeframe: { start_date: "2025-01-01", end_date: "2025-12-31" },
+          contributions: [],
+        }),
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /generate review/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/1\/5/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("progressbar", { name: /generating review/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /generate review/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /premium/i })).not.toBeInTheDocument();
+    jobResolve({ status: "done", result: { themes: { themes: [] }, bullets: {}, stories: {}, self_eval: {} } });
+  });
 });
 
 describe("pollJob", () => {


### PR DESCRIPTION
## Summary

Fixes #104. When a user clicks either Generate button (free or premium), both buttons are now hidden and replaced by a single progress block:

- **Progress block** when `loading`: indeterminate progress bar + step text (e.g. "1/5 Themes")
- **Buttons** when not loading: same free/premium CTAs as before
- Progress text is shown only inside the progress block (no duplicate above)
- Accessibility: `aria-busy` on container, `role="progressbar"`, `aria-label="Generating review"`, `aria-valuetext` for step message

## Changes

- **src/Generate.tsx**: Conditional layout in `.generate-actions` — if `loading`, render `.generate-actions-progress` (bar + message); else render `.generate-actions-buttons`
- **src/Generate.css**: `.generate-actions-progress`, `.generate-progress-bar` with indeterminate CSS animation
- **test/Generate.test.jsx**: New test that when generating (job returns running then hangs), progress UI is visible and generate/premium buttons are not in the DOM

Tests and typecheck pass; build succeeds.