### PR TITLE
Remove PostHog feature flag for Stripe; payments always on when configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In your GitHub OAuth App settings, set the **Authorization callback URL** to `ht
 | Variable | Description |
 |----------|-------------|
 | `DATABASE_URL` | Neon (or any Postgres) connection string. Required for premium credits and Stripe payments; tables `credits` and `credit_events` are created automatically. |
-| `STRIPE_SECRET_KEY` | Stripe secret key. Required for payments (also requires `STRIPE_WEBHOOK_SECRET` and the PostHog feature flag `enable-stripe-payments`). |
+| `STRIPE_SECRET_KEY` | Stripe secret key. Required for payments (also requires `STRIPE_WEBHOOK_SECRET`). |
 | `STRIPE_WEBHOOK_SECRET` | Secret for verifying Stripe webhook signatures. |
 | `STRIPE_PRICE_CENTS` | Price per purchase in cents (default `100` = $1.00). |
 | `STRIPE_CURRENCY` | Payment currency code (default `usd`). |

--- a/docs/STRIPE_KEYS.md
+++ b/docs/STRIPE_KEYS.md
@@ -30,7 +30,7 @@ The app uses Stripe for premium report purchases. You need two keys from your St
 - API keys: <https://dashboard.stripe.com/acct_1SNmB9IoMF0fqmmJ/apikeys>
 - Webhooks: <https://dashboard.stripe.com/webhooks>
 
-Payments are only enabled when `STRIPE_SECRET_KEY` is set and the PostHog feature flag `enable-stripe-payments` is on for the user.
+Payments are enabled when `STRIPE_SECRET_KEY` is set.
 
 ## Stripe best practices (this app)
 
@@ -47,4 +47,4 @@ Payments are only enabled when `STRIPE_SECRET_KEY` is set and the PostHog featur
 2. **Webhook endpoint** – In [Stripe Dashboard → Webhooks](https://dashboard.stripe.com/webhooks), ensure the endpoint URL is your production URL (e.g. `https://annualreview.dev/api/payments/webhook`). Create a separate endpoint for live if you were using test before.
 3. **Webhook signing secret** – Confirm `STRIPE_WEBHOOK_SECRET` is the one from the **live** endpoint (value starts with `whsec_`). Test and live endpoints have different secrets.
 4. **Dynamic payment methods** – In Dashboard, consider enabling [dynamic payment methods](https://docs.stripe.com/payments/payment-methods/integration-options) so Stripe can offer the best options per user.
-5. **App-specific** – This app uses **Checkout Sessions only** (no Charges API, Sources, or Card Element). Webhooks are verified with `stripe.webhooks.constructEvent`; no raw card data is handled. Before enabling for users: turn on the PostHog feature flag `enable-stripe-payments` when ready; confirm `STRIPE_PRICE_CENTS`, `STRIPE_CURRENCY`, and `CREDITS_PER_PURCHASE` are set as intended for production.
+5. **App-specific** – This app uses **Checkout Sessions only** (no Charges API, Sources, or Card Element). Webhooks are verified with `stripe.webhooks.constructEvent`; no raw card data is handled. Confirm `STRIPE_PRICE_CENTS`, `STRIPE_CURRENCY`, and `CREDITS_PER_PURCHASE` are set as intended for production.

--- a/docs/deploy-coolify.md
+++ b/docs/deploy-coolify.md
@@ -30,5 +30,5 @@ The repo includes `nixpacks.toml` so Nixpacks runs `yarn build` and then `yarn s
 - **Required:** `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` (for the webhook handler; see `server/routes/payments.ts`).
 - **Optional:** `STRIPE_PRICE_CENTS` (default `100`), `STRIPE_CURRENCY` (default `usd`), `CREDITS_PER_PURCHASE` (default `5`) — see `server.ts` and `server/routes/payments.ts`.
 - **Where to set:** Local: `.env` (do not commit). Production: Coolify (or similar) → Environment / secrets.
-- **When payments are active:** Only when `STRIPE_SECRET_KEY` is set **and** the PostHog feature flag `enable-stripe-payments` is on for the user (see `server/routes/payments.ts`, `docs/STRIPE_KEYS.md`).
-- **Verify:** `GET /api/payments/config` returns `enabled: true` when Stripe is configured and the flag is on for that user.
+- **When payments are active:** When `STRIPE_SECRET_KEY` is set (see `server/routes/payments.ts`, `docs/STRIPE_KEYS.md`).
+- **Verify:** `GET /api/payments/config` returns `enabled: true` when Stripe is configured.

--- a/server/routes/payments.ts
+++ b/server/routes/payments.ts
@@ -10,18 +10,14 @@
 
 import type { IncomingMessage, ServerResponse } from "http";
 import type { SessionData } from "../../lib/session-store.js";
-import { PostHog } from "posthog-node";
 import Stripe from "stripe";
 import { awardCredits, getCredits, getCreditsPerPurchase } from "../../lib/payment-store.js";
 import { getDefaultModels } from "../../lib/run-pipeline.js";
 import { STRIPE_API_VERSION } from "../config.js";
 
-const PAYMENTS_FEATURE_FLAG_KEY = "enable-stripe-payments";
-
 export interface PaymentsRoutesOptions {
   respondJson: (res: ServerResponse, status: number, data: object) => void;
   getStripe?: () => Stripe | null;
-  getPostHog?: () => PostHog | null;
   getSessionIdFromRequest: (req: IncomingMessage) => string | null;
   getSession: (id: string) => SessionData | undefined;
   /** Optional for tests; when not provided uses real payment store (requires DATABASE_URL). */
@@ -47,43 +43,10 @@ function getStripeClient(): Stripe | null {
   return new Stripe(key, { apiVersion: STRIPE_API_VERSION });
 }
 
-let posthogClient: PostHog | null | undefined;
-function getPostHogClient(): PostHog | null {
-  if (posthogClient !== undefined) return posthogClient;
-  const token = process.env.POSTHOG_API_KEY;
-  if (!token) {
-    posthogClient = null;
-    return posthogClient;
-  }
-  posthogClient = new PostHog(token, {
-    host: process.env.POSTHOG_HOST || "https://us.i.posthog.com",
-  });
-  return posthogClient;
-}
-
-async function isPaymentsEnabledForRequest(
-  req: IncomingMessage,
-  getPostHog: () => PostHog | null,
-  getSessionIdFromRequest: (req: IncomingMessage) => string | null,
-  getSession: (id: string) => SessionData | undefined
-): Promise<boolean> {
-  const posthog = getPostHog();
-  if (!posthog) return false;
-  const sessionId = getSessionIdFromRequest(req);
-  const userSession = sessionId ? getSession(sessionId) : undefined;
-  const distinctId = userSession?.login || "anonymous";
-  try {
-    return !!(await posthog.isFeatureEnabled(PAYMENTS_FEATURE_FLAG_KEY, distinctId));
-  } catch {
-    return false;
-  }
-}
-
 export function paymentsRoutes(options: PaymentsRoutesOptions) {
   const {
     respondJson,
     getStripe = getStripeClient,
-    getPostHog = getPostHogClient,
     getSessionIdFromRequest,
     getSession,
     awardCredits: awardCreditsFn = awardCredits,
@@ -98,14 +61,7 @@ export function paymentsRoutes(options: PaymentsRoutesOptions) {
     const path = (req.url?.split("?")[0] || "").replace(/^\/+/, "") || "";
 
     if (path === "config" && req.method === "GET") {
-      const stripeConfigured = getStripe() !== null;
-      const flagEnabled = await isPaymentsEnabledForRequest(
-        req,
-        getPostHog,
-        getSessionIdFromRequest,
-        getSession
-      );
-      const enabled = stripeConfigured && flagEnabled;
+      const enabled = getStripe() !== null;
       const { free: freeModel, premium: premiumModel } = getDefaultModels();
       respondJson(res, 200, {
         enabled,
@@ -129,16 +85,6 @@ export function paymentsRoutes(options: PaymentsRoutesOptions) {
       return;
     }
     if (path === "checkout" && req.method === "POST") {
-      const flagEnabled = await isPaymentsEnabledForRequest(
-        req,
-        getPostHog,
-        getSessionIdFromRequest,
-        getSession
-      );
-      if (!flagEnabled) {
-        respondJson(res, 503, { error: "Payments are currently disabled" });
-        return;
-      }
       const stripe = getStripe();
       if (!stripe) {
         respondJson(res, 503, { error: "Payments not configured (STRIPE_SECRET_KEY missing)" });

--- a/test/payments.test.js
+++ b/test/payments.test.js
@@ -7,7 +7,6 @@ function makeRouteOptions(overrides = {}) {
   return {
     respondJson,
     getStripe: () => null,
-    getPostHog: () => ({ isFeatureEnabled: vi.fn().mockResolvedValue(true) }),
     getSessionIdFromRequest: () => null,
     getSession: () => undefined,
     ...overrides,
@@ -24,22 +23,7 @@ describe("paymentsRoutes – config", () => {
     expect(res.body).toMatchObject({ enabled: false, price_cents: 100, credits_per_purchase: getCreditsPerPurchase() });
   });
 
-  it("returns enabled:false when feature flag is off", async () => {
-    const mockStripe = { checkout: { sessions: {} } };
-    const handler = paymentsRoutes(
-      makeRouteOptions({
-        getStripe: () => /** @type {any} */ (mockStripe),
-        getPostHog: () => ({ isFeatureEnabled: vi.fn().mockResolvedValue(false) }),
-      })
-    );
-    const req = mockReq("GET", "/config");
-    const res = mockRes();
-    await handler(req, res, () => {});
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({ enabled: false });
-  });
-
-  it("returns enabled:true when Stripe is configured and flag is on", async () => {
+  it("returns enabled:true when Stripe is configured", async () => {
     const mockStripe = { checkout: { sessions: {} } };
     const handler = paymentsRoutes(
       makeRouteOptions({ getStripe: () => /** @type {any} */ (mockStripe) })
@@ -53,23 +37,6 @@ describe("paymentsRoutes – config", () => {
 });
 
 describe("paymentsRoutes – checkout", () => {
-  it("returns 503 when feature flag is disabled", async () => {
-    const handler = paymentsRoutes(
-      makeRouteOptions({
-        getPostHog: () => ({ isFeatureEnabled: vi.fn().mockResolvedValue(false) }),
-      })
-    );
-    const req = mockReq("POST", "/checkout");
-    const res = mockRes();
-    await new Promise((resolve) => {
-      setTimeout(resolve, 50);
-      handler(req, res, resolve);
-    });
-    await new Promise((r) => setTimeout(r, 50));
-    expect(res.statusCode).toBe(503);
-    expect(res.body.error).toMatch(/disabled/i);
-  });
-
   it("returns 503 when STRIPE_SECRET_KEY is not set", async () => {
     const handler = paymentsRoutes(makeRouteOptions({ getStripe: () => null }));
     const req = mockReq("POST", "/checkout");


### PR DESCRIPTION
## Summary

Stripe is always used now; the PostHog feature flag `enable-stripe-payments` is removed.

## Changes

- **server/routes/payments.ts**: Removed PostHog import, `getPostHogClient`, `isPaymentsEnabledForRequest`, and all feature-flag checks. GET `/config` and POST `/checkout` now depend only on `STRIPE_SECRET_KEY` being set.
- **test/payments.test.js**: Dropped `getPostHog` from test options; removed two tests (flag off for config, flag disabled for checkout); renamed one test.
- **Docs**: README, STRIPE_KEYS.md, and deploy-coolify.md updated to state payments are enabled when Stripe is configured (no flag).

## Verification

- `yarn typecheck` ✅
- `yarn test --run` (298 tests) ✅
- `yarn build` ✅