### PR TITLE
refactor: replace collectAndNormalize dynamic imports + unknown cast with validated static imports

### DIFF
--- a/lib/collect-and-normalize.ts
+++ b/lib/collect-and-normalize.ts
@@ -1,4 +1,7 @@
 import type { Evidence } from "../types/evidence.js";
+import { collectRawGraphQL } from "../scripts/collect-github.ts";
+import { normalize } from "../scripts/normalize.ts";
+import { validateEvidence } from "./validate-evidence.js";
 
 export interface CollectOptions {
   token: string;
@@ -7,14 +10,10 @@ export interface CollectOptions {
 }
 
 /**
- * Fetch GitHub data for the authenticated user and return evidence JSON.
- * Uses GraphQL collector (batched) + normalize (evidence contract).
+ * Fetch GitHub data for the authenticated user and return validated evidence JSON.
  * Token is used in-memory only; never stored or logged.
  */
 export async function collectAndNormalize({ token, start_date, end_date }: CollectOptions): Promise<Evidence> {
-  const { collectRawGraphQL } = await import("../scripts/collect-github.ts");
-  const { normalize } = await import("../scripts/normalize.ts");
-
   const raw = await collectRawGraphQL({
     start: start_date,
     end: end_date,
@@ -22,5 +21,12 @@ export async function collectAndNormalize({ token, start_date, end_date }: Colle
     token,
   });
 
-  return normalize(raw, start_date, end_date) as unknown as Evidence;
+  const normalized = normalize(raw, start_date, end_date);
+  const result = validateEvidence(normalized);
+  if (!result.valid) {
+    throw new Error(
+      `Invalid evidence from normalize: ${result.errors.map((e) => e.message).join("; ")}`
+    );
+  }
+  return normalized as Evidence;
 }

--- a/test/collect-and-normalize.test.js
+++ b/test/collect-and-normalize.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from "vitest";
+import { collectAndNormalize } from "../lib/collect-and-normalize.ts";
+
+describe("collectAndNormalize – validation", () => {
+  it("throws a descriptive error when normalize returns invalid evidence shape", async () => {
+    vi.mock("../scripts/collect-github.ts", () => ({
+      collectRawGraphQL: vi.fn().mockResolvedValue({}),
+    }));
+    vi.mock("../scripts/normalize.ts", () => ({
+      normalize: vi.fn().mockReturnValue({ not_evidence: true }),
+    }));
+
+    await expect(
+      collectAndNormalize({ token: "tok", start_date: "2025-01-01", end_date: "2025-12-31" })
+    ).rejects.toThrow(/invalid evidence/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #129
- Replaces `dynamic import()` calls and `as unknown as Evidence` cast in `lib/collect-and-normalize.ts` with static imports of `collectRawGraphQL` and `normalize`
- Adds `validateEvidence()` call after normalization — structural mismatches now produce a descriptive error instead of silently propagating the wrong type
- Adds `test/collect-and-normalize.test.js` with a RED→GREEN test for the validation path

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn test` — 382/382 passing