### PR TITLE
refactor: untangle runPipeline — extract PipelineCache and analytics factory

### DIFF
--- a/lib/run-pipeline.ts
+++ b/lib/run-pipeline.ts
@@ -23,18 +23,95 @@ function loadPrompt(name: string): string {
 
 const SYSTEM_PROMPT = loadPrompt("00_system.md");
 
+// ── PipelineCache ──────────────────────────────────────────────────────────────
+
 const RESULT_CACHE_MAX = 50;
-const resultCache = new Map<string, PipelineResult>();
 
-/** Clear result cache (for tests). */
-export function clearPipelineCache(): void {
-  resultCache.clear();
-}
-
-function cacheKey(evidence: unknown, model: string): string {
+function makeCacheKey(evidence: unknown, model: string): string {
   const str = JSON.stringify({ evidence, model });
   return createHash("sha256").update(str).digest("hex");
 }
+
+/** LRU result cache. Injectable so tests can use isolated instances. */
+export class PipelineCache {
+  private readonly store = new Map<string, PipelineResult>();
+
+  get(evidence: unknown, model: string): PipelineResult | undefined {
+    return this.store.get(makeCacheKey(evidence, model));
+  }
+
+  set(evidence: unknown, model: string, result: PipelineResult): void {
+    const key = makeCacheKey(evidence, model);
+    if (this.store.size >= RESULT_CACHE_MAX) {
+      const firstKey = this.store.keys().next().value;
+      if (firstKey !== undefined) this.store.delete(firstKey);
+    }
+    this.store.set(key, result);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+/** Module-level default cache (shared across all calls that don't inject their own). */
+const defaultCache = new PipelineCache();
+
+/** Clear the default result cache. Prefer injecting a fresh PipelineCache in tests. */
+export function clearPipelineCache(): void {
+  defaultCache.clear();
+}
+
+// ── PostHog client factory ─────────────────────────────────────────────────────
+
+interface PostHogClientResult {
+  openai: OpenAI;
+  posthogOpts: Record<string, string | boolean>;
+  shutdown: () => Promise<void>;
+}
+
+function createOpenAiClient(
+  apiKey: string,
+  baseURL: string | undefined,
+  posthogTraceId: string | undefined,
+  posthogDistinctId: string | undefined
+): PostHogClientResult {
+  const posthogApiKey = process.env.POSTHOG_API_KEY;
+  const posthogClient = posthogApiKey
+    ? new PostHog(posthogApiKey, { host: process.env.POSTHOG_HOST || "https://us.i.posthog.com" })
+    : null;
+
+  const clientOpts: ConstructorParameters<typeof OpenAI>[0] = { apiKey };
+  if (baseURL) {
+    clientOpts.baseURL = baseURL;
+    clientOpts.defaultHeaders = {
+      "HTTP-Referer": "https://annualreview.dev",
+      "X-Title": "AnnualReview.dev",
+    };
+  }
+
+  const openai: OpenAI = posthogClient
+    ? new PostHogOpenAI({
+        ...clientOpts,
+        apiKey,
+        posthog: posthogClient,
+      } as ConstructorParameters<typeof PostHogOpenAI>[0]) as unknown as OpenAI
+    : new OpenAI(clientOpts);
+
+  const posthogOpts: Record<string, string | boolean> = {};
+  if (posthogTraceId != null) posthogOpts.posthogTraceId = posthogTraceId;
+  if (posthogDistinctId != null) posthogOpts.posthogDistinctId = posthogDistinctId;
+  if (posthogClient) posthogOpts.posthogCaptureImmediate = true;
+  if (posthogClient && baseURL?.includes("openrouter.ai")) posthogOpts.posthogProviderOverride = "openrouter";
+
+  return {
+    openai,
+    posthogOpts,
+    shutdown: () => (posthogClient ? posthogClient.shutdown() : Promise.resolve()),
+  };
+}
+
+// ── extractJson ────────────────────────────────────────────────────────────────
 
 /** Pull first {...} from LLM response text and parse as JSON. */
 export function extractJson(text: string): unknown {
@@ -43,6 +120,8 @@ export function extractJson(text: string): unknown {
   if (start === -1 || end === 0) throw new Error("No JSON object in response");
   return JSON.parse(text.slice(start, end));
 }
+
+// ── Pipeline step definitions ──────────────────────────────────────────────────
 
 /** Collect all evidence ids referenced in themes and bullets (and optional stories). */
 function collectEvidenceIds(
@@ -93,7 +172,6 @@ interface PipelineStep {
   buildInput: (evidence: Evidence, prev: PartialPipelineResult) => string;
 }
 
-/** Declarative pipeline steps: key, label, prompt file, and buildInput(evidence, previousResults). */
 const STEPS: PipelineStep[] = [
   {
     key: "themes",
@@ -171,6 +249,8 @@ const STEPS: PipelineStep[] = [
   },
 ];
 
+// ── Public types ───────────────────────────────────────────────────────────────
+
 export interface PipelineResult {
   themes: ThemesOutput;
   bullets: BulletsOutput;
@@ -195,6 +275,8 @@ export interface PipelineOptions {
   }) => void;
   posthogTraceId?: string;
   posthogDistinctId?: string;
+  /** Injectable cache instance. When omitted, uses the module-level default cache. */
+  cache?: PipelineCache;
 }
 
 /** Default model ids for free and premium (OpenRouter). */
@@ -205,7 +287,7 @@ export function getDefaultModels(): { free: string; premium: string } {
   };
 }
 
-/** Max user-message tokens by tier (leaves room for system + response). Env override: MAX_USER_TOKENS_FREE, MAX_USER_TOKENS_PREMIUM. */
+/** Max user-message tokens by tier. Env override: MAX_USER_TOKENS_FREE, MAX_USER_TOKENS_PREMIUM. */
 export function getMaxUserTokensForTier(premium: boolean): number {
   const envKey = premium ? "MAX_USER_TOKENS_PREMIUM" : "MAX_USER_TOKENS_FREE";
   const val = process.env[envKey];
@@ -218,6 +300,8 @@ export function getMaxUserTokensForTier(premium: boolean): number {
 
 const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
 
+// ── Prompt loop ────────────────────────────────────────────────────────────────
+
 export async function runPipeline(
   evidence: Evidence,
   {
@@ -228,14 +312,14 @@ export async function runPipeline(
     onProgress,
     posthogTraceId,
     posthogDistinctId,
+    cache = defaultCache,
   }: PipelineOptions = {}
 ): Promise<PipelineResult> {
   if (!apiKey) throw new Error("OPENROUTER_API_KEY required");
 
   const resolvedModel = model ?? getDefaultModels()[premium ? "premium" : "free"];
 
-  const key = cacheKey(evidence, resolvedModel);
-  const cached = resultCache.get(key);
+  const cached = cache.get(evidence, resolvedModel);
   if (cached) {
     if (typeof onProgress === "function") {
       for (let i = 1; i <= STEPS.length; i++) {
@@ -250,105 +334,83 @@ export async function runPipeline(
     return cached;
   }
 
-  const posthogApiKey = process.env.POSTHOG_API_KEY;
-  const posthogClient = posthogApiKey
-    ? new PostHog(posthogApiKey, { host: process.env.POSTHOG_HOST || "https://us.i.posthog.com" })
-    : null;
-  const clientOpts: ConstructorParameters<typeof OpenAI>[0] = { apiKey };
-  if (baseURL) {
-    clientOpts.baseURL = baseURL;
-    clientOpts.defaultHeaders = {
-      "HTTP-Referer": "https://annualreview.dev",
-      "X-Title": "AnnualReview.dev",
-    };
-  }
-  const posthogOpenAIOptions = {
-    ...clientOpts,
+  const { openai, posthogOpts, shutdown } = createOpenAiClient(
     apiKey,
-    posthog: posthogClient,
-  } as ConstructorParameters<typeof PostHogOpenAI>[0];
-  const openai: OpenAI = posthogClient
-    ? new PostHogOpenAI(posthogOpenAIOptions) as unknown as OpenAI
-    : new OpenAI(clientOpts);
+    baseURL,
+    posthogTraceId,
+    posthogDistinctId
+  );
 
   const total = STEPS.length;
-  const posthogOpts: Record<string, string | boolean> = {};
-  if (posthogTraceId != null) posthogOpts.posthogTraceId = posthogTraceId;
-  if (posthogDistinctId != null) posthogOpts.posthogDistinctId = posthogDistinctId;
-  if (posthogClient) posthogOpts.posthogCaptureImmediate = true; // send each generation immediately so we don't rely on shutdown flush
-  if (posthogClient && baseURL?.includes("openrouter.ai")) posthogOpts.posthogProviderOverride = "openrouter"; // correct $ai_provider in PostHog LLM analytics
 
   try {
-  const totalStart = Date.now();
-  function progress(
-    stepIndex: number,
-    label: string | undefined,
-    extra: Record<string, unknown> = {}
-  ) {
-    if (typeof onProgress === "function") {
-      onProgress({
-        stepIndex,
-        total,
-        step: STEPS[stepIndex - 1].key,
-        label: label || STEPS[stepIndex - 1].label,
-        ...extra,
-      } as Parameters<NonNullable<typeof onProgress>>[0]);
+    const totalStart = Date.now();
+
+    function progress(
+      stepIndex: number,
+      label: string | undefined,
+      extra: Record<string, unknown> = {}
+    ) {
+      if (typeof onProgress === "function") {
+        onProgress({
+          stepIndex,
+          total,
+          step: STEPS[stepIndex - 1].key,
+          label: label || STEPS[stepIndex - 1].label,
+          ...extra,
+        } as Parameters<NonNullable<typeof onProgress>>[0]);
+      }
     }
-  }
 
-  const maxUserTokens = getMaxUserTokensForTier(premium);
-  evidence = fitEvidenceToBudget(evidence, (ev) => STEPS[0].buildInput(ev, {}), maxUserTokens);
+    const maxUserTokens = getMaxUserTokensForTier(premium);
+    evidence = fitEvidenceToBudget(evidence, (ev) => STEPS[0].buildInput(ev, {}), maxUserTokens);
 
-  const previousResults: PartialPipelineResult = {};
-  let prevStepMs: number | undefined;
-  let prevStepPayloadTokens: number | undefined;
+    const previousResults: PartialPipelineResult = {};
+    let prevStepMs: number | undefined;
+    let prevStepPayloadTokens: number | undefined;
 
-  for (let stepIndex = 1; stepIndex <= total; stepIndex++) {
-    const step = STEPS[stepIndex - 1];
-    progress(stepIndex, undefined, stepIndex === 1 ? {} : { prevStepMs, prevStepPayloadTokens });
+    for (let stepIndex = 1; stepIndex <= total; stepIndex++) {
+      const step = STEPS[stepIndex - 1];
+      progress(stepIndex, undefined, stepIndex === 1 ? {} : { prevStepMs, prevStepPayloadTokens });
 
-    const stepStart = Date.now();
-    const input = step.buildInput(evidence, previousResults);
-    const promptContent = loadPrompt(step.promptFile);
-    const completion = await openai.chat.completions.create({
-      model: resolvedModel,
-      messages: [
-        { role: "system", content: SYSTEM_PROMPT },
-        { role: "user", content: `${promptContent}\n\nINPUT JSON:\n${input}` },
-      ],
-      ...posthogOpts,
-    });
-    const rawContent = completion.choices[0]?.message?.content;
-    if (rawContent == null || (typeof rawContent === "string" && rawContent.trim() === "")) {
-      throw new Error(`Pipeline step "${step.key}" returned no content`);
+      const stepStart = Date.now();
+      const input = step.buildInput(evidence, previousResults);
+      const promptContent = loadPrompt(step.promptFile);
+      const completion = await openai.chat.completions.create({
+        model: resolvedModel,
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: `${promptContent}\n\nINPUT JSON:\n${input}` },
+        ],
+        ...posthogOpts,
+      });
+      const rawContent = completion.choices[0]?.message?.content;
+      if (rawContent == null || (typeof rawContent === "string" && rawContent.trim() === "")) {
+        throw new Error(`Pipeline step "${step.key}" returned no content`);
+      }
+      let stepResult: unknown;
+      try {
+        stepResult = extractJson(rawContent);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Step ${step.key} returned invalid JSON: ${msg}`);
+      }
+      (previousResults as Record<string, unknown>)[step.key] = stepResult;
+      prevStepMs = Date.now() - stepStart;
+      prevStepPayloadTokens = estimateTokens(input);
     }
-    let stepResult: unknown;
-    try {
-      stepResult = extractJson(rawContent);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      throw new Error(`Step ${step.key} returned invalid JSON: ${msg}`);
-    }
-    (previousResults as Record<string, unknown>)[step.key] = stepResult;
-    prevStepMs = Date.now() - stepStart;
-    prevStepPayloadTokens = estimateTokens(input);
-  }
 
-  progress(total, undefined, { prevStepMs, prevStepPayloadTokens, totalMs: Date.now() - totalStart });
+    progress(total, undefined, { prevStepMs, prevStepPayloadTokens, totalMs: Date.now() - totalStart });
 
-  const result: PipelineResult = {
-    themes: previousResults.themes as ThemesOutput,
-    bullets: previousResults.bullets as BulletsOutput,
-    stories: previousResults.stories as StoriesOutput,
-    self_eval: previousResults.self_eval as SelfEvalOutput,
-  };
-  if (resultCache.size >= RESULT_CACHE_MAX) {
-    const firstKey = resultCache.keys().next().value;
-    if (firstKey !== undefined) resultCache.delete(firstKey);
-  }
-  resultCache.set(key, result);
-  return result;
+    const result: PipelineResult = {
+      themes: previousResults.themes as ThemesOutput,
+      bullets: previousResults.bullets as BulletsOutput,
+      stories: previousResults.stories as StoriesOutput,
+      self_eval: previousResults.self_eval as SelfEvalOutput,
+    };
+    cache.set(evidence, resolvedModel, result);
+    return result;
   } finally {
-    if (posthogClient) await posthogClient.shutdown();
+    await shutdown();
   }
 }

--- a/test/run-pipeline.test.js
+++ b/test/run-pipeline.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { extractJson, runPipeline, clearPipelineCache, getMaxUserTokensForTier } from "../lib/run-pipeline.js";
+import { extractJson, runPipeline, clearPipelineCache, getMaxUserTokensForTier, PipelineCache } from "../lib/run-pipeline.js";
 
 const mockThemes = { themes: [{ theme_id: "t1", theme_name: "Reliability" }] };
 const mockBullets = { bullets_by_theme: [], top_10_bullets_overall: [] };
@@ -323,6 +323,23 @@ describe("runPipeline", () => {
     };
     const result = await runPipeline(evidence, { apiKey: "sk-test" });
     expect(result.themes).toBeDefined();
+  });
+
+  it("injectable PipelineCache isolates cache state between test instances", async () => {
+    const cache1 = new PipelineCache();
+    const cache2 = new PipelineCache();
+    const evidence = {
+      timeframe: { start_date: "2025-01-01", end_date: "2025-12-31" },
+      contributions: [],
+    };
+    await runPipeline(evidence, { apiKey: "sk-test", cache: cache1 });
+    const callsAfterFirst = createCallCount;
+    await runPipeline(evidence, { apiKey: "sk-test", cache: cache2 });
+    // cache2 is fresh — should call LLM again
+    expect(createCallCount).toBe(callsAfterFirst + 4);
+    await runPipeline(evidence, { apiKey: "sk-test", cache: cache1 });
+    // cache1 hit — no more calls
+    expect(createCallCount).toBe(callsAfterFirst + 4);
   });
 
   it("throws step-specific error when LLM returns malformed JSON for a step", async () => {


### PR DESCRIPTION
## Summary

- Closes #127
- Extracts `PipelineCache` class — injectable, LRU, isolated per instance. Tests can now pass `new PipelineCache()` instead of calling `clearPipelineCache()` on module-level state
- Extracts `createOpenAiClient` factory — all PostHog wiring (client construction, opts assembly, shutdown) lives there instead of inline in `runPipeline`
- `runPipeline` now owns only: token budget enforcement + prompt loop
- `clearPipelineCache()` kept for backward compatibility (clears the module-level default cache)
- `PipelineOptions.cache` field added for test isolation

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn test` — 382/382 passing (1 new test for injectable cache isolation)