### PR TITLE
Add Conductor settings for parallel workspace dev

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,7 @@
+#:schema https://conductor.build/schemas/settings.repo.schema.json
+
+[scripts]
+setup = "yarn install --frozen-lockfile && test -f \"$CONDUCTOR_ROOT_PATH/.env\" && ln -sf \"$CONDUCTOR_ROOT_PATH/.env\" .env || true"
+run = "yarn dev --port $CONDUCTOR_PORT"
+archive = "true"
+run_mode = "concurrent"


### PR DESCRIPTION
## Summary
Adds `.conductor/settings.toml` so Conductor workspaces share setup, run, and archive scripts for this repo. Setup installs dependencies with `yarn install --frozen-lockfile` and symlinks `.env` from the repo root when present. Run starts the Vite dev server on `CONDUCTOR_PORT` so multiple workspaces can run concurrently.

## Test plan
- [ ] Create or open a Conductor workspace and confirm setup completes
- [ ] Click Run and verify Vite starts on the assigned port
- [ ] Open the app in a browser at `http://localhost:$CONDUCTOR_PORT`


Made with [Cursor](https://cursor.com)