### PR TITLE
fix(deploy): harden Coolify/Nixpacks build for Node server runtime

### DIFF
--- a/docs/deploy-coolify.md
+++ b/docs/deploy-coolify.md
@@ -2,6 +2,8 @@
 
 The repo includes `nixpacks.toml` so Nixpacks runs `yarn build` and then `yarn start` (the Node server). That way the API routes exist in production; without it, Nixpacks might only serve static files and Connect would 404.
 
+`nixpacks.toml` pins Node **22.22+** (required by `@posthog/ai`), disables the Nixpacks Caddy SPA layer (`NIXPACKS_SPA_CADDY=false`) so the container runs `yarn start` instead of serving static files only, and ensures devDependencies install during the build (Vite) while keeping `tsx` as a runtime dependency for `server.ts`.
+
 1. **Build & start** (handled by Nixpacks via `nixpacks.toml`)
    - Build: `yarn build`
    - Start: `yarn start` (Node server serves `dist/` + `/api/*`)

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,9 +1,17 @@
 # Coolify/Nixpacks: build Vite app then run Node server (API + static).
 # Without this, Nixpacks may treat the app as static-only and not run server.ts.
-# Nixpacks Node 22 image is 22.19.x; @posthog/ai wants >=22.22.0. Ignore engine check so install succeeds.
+# Default Nixpacks Node 22 is 22.19.x; @posthog/ai requires >=22.22.0.
+
+[phases.setup]
+nixpkgsArchive = "f3dfef5ce7283255d11e2327b9fdf08c660dabe8"
+
+[variables]
+NIXPACKS_SPA_CADDY = "false"
+NPM_CONFIG_PRODUCTION = "false"
+YARN_PRODUCTION = "false"
 
 [phases.install]
-cmds = ["yarn install --frozen-lockfile --ignore-engines"]
+cmds = ["yarn install --frozen-lockfile --ignore-engines --production=false"]
 
 [phases.build]
 cmds = ["yarn build"]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.22.0"
   },
   "resolutions": {
     "vite": "6.4.1"
@@ -41,7 +41,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "10.1.0",
-    "stripe": "20.4.0"
+    "stripe": "20.4.0",
+    "tsx": "^4.21.0"
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
@@ -57,7 +58,6 @@
     "@vitest/ui": "4.0.18",
     "dotenv": "^16.4.5",
     "jsdom": "^28.1.0",
-    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vite": "^6.0.3",
     "vitest": "^4.0.18"

--- a/test/nixpacks-config.test.js
+++ b/test/nixpacks-config.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+
+describe("Coolify/Nixpacks deploy config", () => {
+  const nixpacks = readFileSync("nixpacks.toml", "utf8");
+  const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+
+  it("pins Node 22.22+ via nixpkgsArchive", () => {
+    expect(nixpacks).toMatch(/nixpkgsArchive\s*=\s*["']f3dfef5/);
+  });
+
+  it("disables Caddy SPA layer (Node server serves dist + API)", () => {
+    expect(nixpacks).toMatch(/NIXPACKS_SPA_CADDY\s*=\s*["']false["']/);
+  });
+
+  it("installs devDependencies during the Nixpacks build", () => {
+    expect(nixpacks).toMatch(/production\s*=\s*false/);
+    expect(nixpacks).toMatch(/NPM_CONFIG_PRODUCTION\s*=\s*["']false["']/);
+  });
+
+  it("keeps tsx as a runtime dependency for server.ts", () => {
+    expect(pkg.dependencies?.tsx).toBeDefined();
+    expect(pkg.devDependencies?.tsx).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Disable Nixpacks Caddy SPA layer (`NIXPACKS_SPA_CADDY=false`) so Coolify runs `yarn start` instead of building a flaky extra Nix/Caddy step
- Pin Node 22.22+ via `nixpkgsArchive` to satisfy `@posthog/ai` and match `.nvmrc`
- Move `tsx` to runtime dependencies and ensure devDependencies install during the Nixpacks build (Vite)
- Add `test/nixpacks-config.test.js` to guard deploy settings

## Context
Coolify deploy of `71f1085` failed during the Caddy `nix-env` step (transient Nix cache download). A retry succeeded, but this removes the unnecessary Caddy phase and hardens install/runtime deps.

## Test plan
- [x] `yarn test:coverage`
- [x] `yarn typecheck`
- [x] `yarn build`
- [ ] Merge and verify Coolify deploy succeeds on main


Made with [Cursor](https://cursor.com)