### PR TITLE
architecture: deepen the evidence intake module

### DIFF
--- a/lib/collect-and-normalize.ts
+++ b/lib/collect-and-normalize.ts
@@ -1,32 +1,5 @@
-import type { Evidence } from "../types/evidence.js";
-import { collectRawGraphQL } from "../scripts/collect-github.ts";
-import { normalize } from "../scripts/normalize.ts";
-import { validateEvidence } from "./validate-evidence.js";
-
-export interface CollectOptions {
-  token: string;
-  start_date: string;
-  end_date: string;
-}
-
-/**
- * Fetch GitHub data for the authenticated user and return validated evidence JSON.
- * Token is used in-memory only; never stored or logged.
- */
-export async function collectAndNormalize({ token, start_date, end_date }: CollectOptions): Promise<Evidence> {
-  const raw = await collectRawGraphQL({
-    start: start_date,
-    end: end_date,
-    noReviews: false,
-    token,
-  });
-
-  const normalized = normalize(raw, start_date, end_date);
-  const result = validateEvidence(normalized);
-  if (!result.valid) {
-    throw new Error(
-      `Invalid evidence from normalize: ${result.errors.map((e) => e.message).join("; ")}`
-    );
-  }
-  return normalized as Evidence;
-}
+/** @deprecated Use lib/evidence-intake.ts — kept for backward-compatible imports. */
+export {
+  intakeFromGitHub as collectAndNormalize,
+  type IntakeFromGitHubOptions as CollectOptions,
+} from "./evidence-intake.js";

--- a/lib/evidence-intake.ts
+++ b/lib/evidence-intake.ts
@@ -1,0 +1,127 @@
+/**
+ * Evidence intake — single seam for fetch → normalize → validate.
+ * Web routes, periodic collection, and CLI adapters call this module.
+ */
+
+import type { Evidence } from "../types/evidence.js";
+import { collectRawGraphQL } from "../scripts/collect-github.ts";
+import { normalize, type RawGitHubInput } from "../scripts/normalize.ts";
+import { validateEvidence } from "./validate-evidence.js";
+
+export const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export class EvidenceIntakeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EvidenceIntakeError";
+  }
+}
+
+export interface Timeframe {
+  start_date: string;
+  end_date: string;
+}
+
+/** Validates YYYY-MM-DD dates and start <= end. */
+export function parseTimeframe(start_date: unknown, end_date: unknown): Timeframe {
+  if (
+    typeof start_date !== "string" ||
+    typeof end_date !== "string" ||
+    !DATE_RE.test(start_date) ||
+    !DATE_RE.test(end_date)
+  ) {
+    throw new EvidenceIntakeError("start_date and end_date must be YYYY-MM-DD");
+  }
+  if (start_date > end_date) {
+    throw new EvidenceIntakeError("start_date must be on or before end_date");
+  }
+  return { start_date, end_date };
+}
+
+const TOKEN_REQUIRED =
+  "GitHub token required (sign in with GitHub or pass token in body)";
+
+/** Requires a non-empty GitHub token string. */
+export function requireGitHubToken(token: unknown): string {
+  if (typeof token !== "string" || !token.trim()) {
+    throw new EvidenceIntakeError(TOKEN_REQUIRED);
+  }
+  return token;
+}
+
+/** Resolves token from body override, then session. */
+export function resolveGitHubToken(opts: {
+  body?: unknown;
+  session?: unknown;
+}): string {
+  const bodyToken = typeof opts.body === "string" ? opts.body : undefined;
+  const sessionToken = typeof opts.session === "string" ? opts.session : undefined;
+  return requireGitHubToken(bodyToken ?? sessionToken);
+}
+
+function assertValidEvidence(data: unknown): Evidence {
+  const result = validateEvidence(data);
+  if (!result.valid) {
+    throw new EvidenceIntakeError(
+      `Invalid evidence: ${result.errors.map((e) => e.message).join("; ")}`
+    );
+  }
+  return data as Evidence;
+}
+
+export interface IntakeFromRawOptions {
+  start_date?: string | null;
+  end_date?: string | null;
+}
+
+/** Normalize raw GitHub JSON and validate against the evidence schema. */
+export function intakeFromRaw(
+  raw: RawGitHubInput,
+  opts: IntakeFromRawOptions = {}
+): Evidence {
+  const start = opts.start_date ?? null;
+  const end = opts.end_date ?? null;
+  if (start != null || end != null) {
+    parseTimeframe(
+      start ?? raw.timeframe?.start_date ?? "",
+      end ?? raw.timeframe?.end_date ?? ""
+    );
+  }
+  const normalized = normalize(raw, start, end);
+  return assertValidEvidence(normalized);
+}
+
+export interface IntakeFromGitHubOptions {
+  token: string;
+  start_date: string;
+  end_date: string;
+  noReviews?: boolean;
+  fetchFn?: typeof fetch;
+}
+
+export interface IntakeFromGitHubDeps {
+  collectRawGraphQL?: typeof collectRawGraphQL;
+}
+
+/**
+ * Fetch GitHub data for the authenticated user and return validated evidence.
+ * Token is used in-memory only; never stored or logged.
+ */
+export async function intakeFromGitHub(
+  opts: IntakeFromGitHubOptions,
+  deps: IntakeFromGitHubDeps = {}
+): Promise<Evidence> {
+  const { start_date, end_date } = parseTimeframe(opts.start_date, opts.end_date);
+  const token = requireGitHubToken(opts.token);
+  const collect = deps.collectRawGraphQL ?? collectRawGraphQL;
+
+  const raw = await collect({
+    start: start_date,
+    end: end_date,
+    noReviews: opts.noReviews ?? false,
+    token,
+    fetchFn: opts.fetchFn,
+  });
+
+  return intakeFromRaw(raw, { start_date, end_date });
+}

--- a/scripts/collect-github.ts
+++ b/scripts/collect-github.ts
@@ -7,6 +7,7 @@
 import { writeFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { parseArgs as parseArgsBase } from "../lib/parse-args.ts";
+import { parseTimeframe, requireGitHubToken } from "../lib/evidence-intake.ts";
 
 const GITHUB_GRAPHQL = "https://api.github.com/graphql";
 
@@ -307,23 +308,23 @@ export async function collectRawGraphQL({
 }
 
 async function main(): Promise<void> {
-  const token = process.env.GITHUB_TOKEN;
-  if (!token) {
-    console.error("GITHUB_TOKEN required");
-    process.exit(1);
-  }
   const parsed = parseArgs();
-  const start = parsed.start as string | undefined;
-  const end = parsed.end as string | undefined;
   const output = parsed.output as string | undefined;
   const noReviews = parsed.noReviews as boolean | undefined;
-  if (!start || !end) {
-    console.error("--start YYYY-MM-DD and --end YYYY-MM-DD required");
+
+  let token: string;
+  let start_date: string;
+  let end_date: string;
+  try {
+    token = requireGitHubToken(process.env.GITHUB_TOKEN);
+    ({ start_date, end_date } = parseTimeframe(parsed.start, parsed.end));
+  } catch (e) {
+    console.error((e as Error).message);
     process.exit(1);
   }
   const raw = await collectRawGraphQL({
-    start,
-    end,
+    start: start_date,
+    end: end_date,
     noReviews: noReviews ?? false,
     token,
   });

--- a/scripts/normalize.ts
+++ b/scripts/normalize.ts
@@ -7,6 +7,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { parseArgs as parseArgsBase } from "../lib/parse-args.ts";
+import { intakeFromRaw } from "../lib/evidence-intake.ts";
 import type { Contribution } from "../types/evidence.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -345,7 +346,10 @@ function main(): void {
     throw e;
   }
 
-  const evidence = normalize(raw, start ?? null, end ?? null);
+  const evidence = intakeFromRaw(raw, {
+    start_date: start ?? null,
+    end_date: end ?? null,
+  });
   writeFileSync(outputPath, JSON.stringify(evidence, null, 2), "utf8");
   console.log(
     "Wrote",

--- a/server.ts
+++ b/server.ts
@@ -18,7 +18,7 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const DIST = join(__dirname, "dist");
 
 import { runPipeline } from "./lib/run-pipeline.ts";
-import { collectAndNormalize } from "./lib/collect-and-normalize.ts";
+import { intakeFromGitHub } from "./lib/evidence-intake.ts";
 import { validateEvidence } from "./lib/validate-evidence.ts";
 import {
   createJob,
@@ -208,7 +208,7 @@ function handleRequest(
         getSession,
         createJob,
         runInBackground,
-        collectAndNormalize,
+        intakeFromGitHub,
       })(wrappedReq, res, next);
       return;
     }
@@ -223,7 +223,7 @@ function handleRequest(
       periodicRoutes({
         getSessionIdFromRequest: getSessionId,
         getSession,
-        collectAndNormalize,
+        intakeFromGitHub,
       })(wrappedReq, res, next);
       return;
     }

--- a/server/routes/collect.ts
+++ b/server/routes/collect.ts
@@ -4,8 +4,16 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "http";
+import type { Evidence } from "../../types/evidence.js";
 import type { SessionData } from "../../lib/session-store.js";
-import { readJsonBody, respondJson, DATE_YYYY_MM_DD } from "../helpers.js";
+import {
+  EvidenceIntakeError,
+  intakeFromGitHub,
+  parseTimeframe,
+  resolveGitHubToken,
+  type IntakeFromGitHubOptions,
+} from "../../lib/evidence-intake.js";
+import { readJsonBody, respondJson } from "../helpers.js";
 
 export interface CollectRoutesOptions {
   getSessionIdFromRequest: (req: IncomingMessage) => string | null;
@@ -15,11 +23,7 @@ export interface CollectRoutesOptions {
     jobId: string,
     fn: () => void | Promise<unknown>
   ) => void;
-  collectAndNormalize: (opts: {
-    token: string;
-    start_date: string;
-    end_date: string;
-  }) => Promise<unknown>;
+  intakeFromGitHub?: (opts: IntakeFromGitHubOptions) => Promise<Evidence>;
 }
 
 type Next = () => void;
@@ -30,8 +34,8 @@ export function collectRoutes(options: CollectRoutesOptions) {
     getSession,
     createJob,
     runInBackground,
-    collectAndNormalize,
   } = options;
+  const runIntake = options.intakeFromGitHub ?? intakeFromGitHub;
 
   return async function collectMiddleware(
     req: IncomingMessage,
@@ -48,30 +52,28 @@ export function collectRoutes(options: CollectRoutesOptions) {
         end_date?: string;
         token?: string;
       };
-      const { start_date, end_date } = body;
-      if (
-        !start_date ||
-        !end_date ||
-        !DATE_YYYY_MM_DD.test(start_date) ||
-        !DATE_YYYY_MM_DD.test(end_date)
-      ) {
-        respondJson(res, 400, {
-          error: "start_date and end_date must be YYYY-MM-DD",
-        });
-        return;
-      }
       const sessionId = getSessionIdFromRequest(req);
       const session = sessionId ? getSession(sessionId) : undefined;
-      const token = body.token ?? session?.access_token;
-      if (!token || typeof token !== "string") {
-        respondJson(res, 401, {
-          error: "token required (sign in with GitHub or send token in body)",
+      let start_date: string;
+      let end_date: string;
+      let token: string;
+      try {
+        ({ start_date, end_date } = parseTimeframe(body.start_date, body.end_date));
+        token = resolveGitHubToken({
+          body: body.token,
+          session: session?.access_token,
         });
-        return;
+      } catch (e) {
+        if (e instanceof EvidenceIntakeError) {
+          const status = e.message.includes("token") ? 401 : 400;
+          respondJson(res, status, { error: e.message });
+          return;
+        }
+        throw e;
       }
       const jobId = createJob("collect", sessionId ?? undefined);
       runInBackground(jobId, () =>
-        collectAndNormalize({ token, start_date, end_date })
+        runIntake({ token, start_date, end_date })
       );
       respondJson(res, 202, { job_id: jobId });
     } catch (e) {

--- a/server/routes/periodic.ts
+++ b/server/routes/periodic.ts
@@ -16,6 +16,13 @@
 import type { IncomingMessage, ServerResponse } from "http";
 import type { SessionData } from "../../lib/session-store.js";
 import type { Evidence } from "../../types/evidence.js";
+import {
+  EvidenceIntakeError,
+  intakeFromGitHub,
+  parseTimeframe,
+  resolveGitHubToken,
+  type IntakeFromGitHubOptions,
+} from "../../lib/evidence-intake.js";
 import type {
   PeriodicSummary,
   PeriodicSummaryWithEvidence,
@@ -29,7 +36,7 @@ export interface PeriodicRoutesOptions {
   readJsonBody?: (req: IncomingMessage) => Promise<object>;
   getSessionIdFromRequest: (req: IncomingMessage) => string | null;
   getSession: (id: string) => SessionData | undefined;
-  collectAndNormalize: (opts: { token: string; start_date: string; end_date: string }) => Promise<Evidence>;
+  intakeFromGitHub?: (opts: IntakeFromGitHubOptions) => Promise<Evidence>;
   /** Injected for tests */
   runDailySummary?: (evidence: Evidence) => Promise<string>;
   runWeeklyRollup?: (weekStart: string, weekEnd: string, dailyJsons: string[]) => Promise<string>;
@@ -54,8 +61,9 @@ const DEFAULT_SUMMARIES_LIMIT = 90;
 const MAX_SUMMARIES_LIMIT = 365;
 
 export function periodicRoutes(options: PeriodicRoutesOptions) {
-  const { getSessionIdFromRequest, getSession, collectAndNormalize } = options;
+  const { getSessionIdFromRequest, getSession } = options;
   const readJsonBody = options.readJsonBody ?? defaultReadJsonBody;
+  const runIntake = options.intakeFromGitHub ?? intakeFromGitHub;
 
   async function getStore() {
     const allProvided =
@@ -154,22 +162,28 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
       const date = (body.date as string | undefined) ??
         new Date().toISOString().slice(0, 10);
 
-      if (!DATE_RE.test(date)) {
-        respondJson(res, 400, { error: "date must be YYYY-MM-DD" });
-        return;
-      }
-
-      // Resolve token: body > session
       const sessId = getSessionIdFromRequest(req);
       const session = sessId ? getSession(sessId) : undefined;
-      const token = (body.token as string | undefined) ?? session?.access_token;
-      if (!token) {
-        respondJson(res, 401, { error: "GitHub token required (login with GitHub or pass token in body)" });
-        return;
+      let start_date: string;
+      let end_date: string;
+      let token: string;
+      try {
+        ({ start_date, end_date } = parseTimeframe(date, date));
+        token = resolveGitHubToken({
+          body: body.token,
+          session: session?.access_token,
+        });
+      } catch (e) {
+        if (e instanceof EvidenceIntakeError) {
+          const status = e.message.includes("token") ? 401 : 400;
+          respondJson(res, status, { error: e.message });
+          return;
+        }
+        throw e;
       }
 
       try {
-        const evidence = await collectAndNormalize({ token, start_date: date, end_date: date });
+        const evidence = await runIntake({ token, start_date, end_date });
         const summaryJson = await store.runDailySummary(evidence);
         const id = await store.saveDailySummary(userLogin, date, evidence, summaryJson);
         let parsedSummary: unknown = summaryJson;

--- a/test/collect-and-normalize.test.js
+++ b/test/collect-and-normalize.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { collectAndNormalize } from "../lib/collect-and-normalize.ts";
 
-describe("collectAndNormalize – validation", () => {
-  it("throws a descriptive error when normalize returns invalid evidence shape", async () => {
+describe("collectAndNormalize (deprecated alias)", () => {
+  it("delegates to evidence intake and throws on invalid evidence", async () => {
     vi.mock("../scripts/collect-github.ts", () => ({
       collectRawGraphQL: vi.fn().mockResolvedValue({}),
     }));

--- a/test/evidence-intake.test.js
+++ b/test/evidence-intake.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as normalizeModule from "../scripts/normalize.ts";
+import {
+  DATE_RE,
+  EvidenceIntakeError,
+  parseTimeframe,
+  requireGitHubToken,
+  resolveGitHubToken,
+  intakeFromGitHub,
+  intakeFromRaw,
+} from "../lib/evidence-intake.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("evidence-intake – invariants", () => {
+  it("DATE_RE accepts YYYY-MM-DD and rejects other formats", () => {
+    expect(DATE_RE.test("2025-01-01")).toBe(true);
+    expect(DATE_RE.test("2025-1-01")).toBe(false);
+    expect(DATE_RE.test("01/01/2025")).toBe(false);
+  });
+
+  it("parseTimeframe rejects missing or invalid dates", () => {
+    expect(() => parseTimeframe(undefined, "2025-01-01")).toThrow(EvidenceIntakeError);
+    expect(() => parseTimeframe("2025-01-01", "bad")).toThrow(/YYYY-MM-DD/);
+  });
+
+  it("parseTimeframe rejects start_date after end_date", () => {
+    expect(() => parseTimeframe("2025-12-31", "2025-01-01")).toThrow(/on or before/);
+  });
+
+  it("parseTimeframe accepts a single-day range", () => {
+    expect(parseTimeframe("2025-01-15", "2025-01-15")).toEqual({
+      start_date: "2025-01-15",
+      end_date: "2025-01-15",
+    });
+  });
+
+  it("requireGitHubToken rejects missing or empty tokens", () => {
+    expect(() => requireGitHubToken(undefined)).toThrow(/token required/i);
+    expect(() => requireGitHubToken("   ")).toThrow(/token required/i);
+  });
+
+  it("resolveGitHubToken prefers body token over session token", () => {
+    expect(resolveGitHubToken({ body: "body_tok", session: "sess_tok" })).toBe("body_tok");
+    expect(resolveGitHubToken({ session: "sess_tok" })).toBe("sess_tok");
+  });
+});
+
+describe("intakeFromRaw", () => {
+  it("returns validated evidence from raw GitHub JSON", () => {
+    const raw = {
+      timeframe: { start_date: "2025-01-01", end_date: "2025-01-31" },
+      pull_requests: [
+        {
+          number: 1,
+          title: "Fix",
+          url: "https://github.com/a/b/pull/1",
+          base: { repo: { full_name: "a/b" } },
+          merged_at: "2025-01-15T00:00:00Z",
+        },
+      ],
+    };
+    const evidence = intakeFromRaw(raw, { start_date: "2025-01-01", end_date: "2025-01-31" });
+    expect(evidence.contributions).toHaveLength(1);
+    expect(evidence.timeframe).toEqual({ start_date: "2025-01-01", end_date: "2025-01-31" });
+  });
+
+  it("throws when normalize output fails schema validation", () => {
+    vi.spyOn(normalizeModule, "normalize").mockReturnValue({ not_evidence: true });
+    expect(() => intakeFromRaw({})).toThrow(/invalid evidence/i);
+  });
+});
+
+describe("intakeFromGitHub", () => {
+  it("fetches, normalizes, and validates in order", async () => {
+    const collectRawGraphQL = vi.fn().mockResolvedValue({
+      timeframe: { start_date: "2025-01-01", end_date: "2025-01-31" },
+      pull_requests: [
+        {
+          number: 2,
+          title: "Feature",
+          url: "https://github.com/a/b/pull/2",
+          base: { repo: { full_name: "a/b" } },
+          merged_at: "2025-01-10T00:00:00Z",
+        },
+      ],
+    });
+
+    const evidence = await intakeFromGitHub(
+      { token: "tok", start_date: "2025-01-01", end_date: "2025-01-31" },
+      { collectRawGraphQL }
+    );
+
+    expect(collectRawGraphQL).toHaveBeenCalledWith({
+      start: "2025-01-01",
+      end: "2025-01-31",
+      noReviews: false,
+      token: "tok",
+      fetchFn: undefined,
+    });
+    expect(evidence.contributions).toHaveLength(1);
+  });
+
+  it("rejects invalid timeframe before fetching", async () => {
+    const collectRawGraphQL = vi.fn();
+    await expect(
+      intakeFromGitHub({ token: "tok", start_date: "bad", end_date: "2025-01-01" }, { collectRawGraphQL })
+    ).rejects.toThrow(EvidenceIntakeError);
+    expect(collectRawGraphQL).not.toHaveBeenCalled();
+  });
+});

--- a/test/routes-collect.test.js
+++ b/test/routes-collect.test.js
@@ -8,7 +8,7 @@ function makeOptions(overrides = {}) {
     getSession: () => undefined,
     createJob: vi.fn().mockReturnValue("job_1"),
     runInBackground: vi.fn(),
-    collectAndNormalize: vi.fn().mockResolvedValue({ contributions: [] }),
+    intakeFromGitHub: vi.fn().mockResolvedValue({ contributions: [] }),
     ...overrides,
   };
 }
@@ -66,11 +66,11 @@ describe("collectRoutes – POST /", () => {
   });
 
   it("prefers body token over session token when both are provided", async () => {
-    const collectAndNormalize = vi.fn().mockResolvedValue({ contributions: [] });
+    const intakeFromGitHub = vi.fn().mockResolvedValue({ contributions: [] });
     const opts = makeOptions({
       getSessionIdFromRequest: () => "sess_1",
       getSession: () => ({ access_token: "ghp_session_token", login: "user1" }),
-      collectAndNormalize,
+      intakeFromGitHub,
     });
     const handler = collectRoutes(opts);
     const req = mockReq("POST", "/", { start_date: "2025-01-01", end_date: "2025-12-31", token: "ghp_pat_token" });
@@ -79,7 +79,7 @@ describe("collectRoutes – POST /", () => {
     expect(res.statusCode).toBe(202);
     const bgFn = opts.runInBackground.mock.calls[0][1];
     await bgFn();
-    expect(collectAndNormalize).toHaveBeenCalledWith(expect.objectContaining({ token: "ghp_pat_token" }));
+    expect(intakeFromGitHub).toHaveBeenCalledWith(expect.objectContaining({ token: "ghp_pat_token" }));
   });
 
   it("returns 500 on unexpected errors", async () => {

--- a/test/routes-periodic.test.js
+++ b/test/routes-periodic.test.js
@@ -25,7 +25,7 @@ function makeOptions(overrides = {}) {
     respondJson,
     getSessionIdFromRequest: () => null,
     getSession: () => undefined,
-    collectAndNormalize: vi.fn().mockResolvedValue(SAMPLE_EVIDENCE),
+    intakeFromGitHub: vi.fn().mockResolvedValue(SAMPLE_EVIDENCE),
     runDailySummary: vi.fn().mockResolvedValue(SAMPLE_DAILY_JSON),
     runWeeklyRollup: vi.fn().mockResolvedValue(JSON.stringify({
       week_start: "2025-01-13",
@@ -153,7 +153,7 @@ describe("periodicRoutes – POST /collect-day", () => {
       getSessionIdFromRequest: () => "sess1",
       getSession: () => SESSION,
       readJsonBody: vi.fn().mockResolvedValue({ date: "2025-01-15" }),
-      collectAndNormalize: mockCollect,
+      intakeFromGitHub: mockCollect,
       runDailySummary: mockSummary,
       saveDailySummary: mockSave,
     });
@@ -180,7 +180,7 @@ describe("periodicRoutes – POST /collect-day", () => {
       getSessionIdFromRequest: () => "sess1",
       getSession: () => SESSION, // has access_token: "gh_tok"
       readJsonBody: vi.fn().mockResolvedValue({ date: "2025-01-15" }),
-      collectAndNormalize: mockCollect,
+      intakeFromGitHub: mockCollect,
     });
     const handler = periodicRoutes(opts);
     const req = mockReq("POST", "/collect-day");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, loadEnv, type ConfigEnv, type ViteDevServer } from "vite"
 import react from "@vitejs/plugin-react";
 import { codecovVitePlugin } from "@codecov/vite-plugin";
 import { runPipeline } from "./lib/run-pipeline.js";
-import { collectAndNormalize } from "./lib/collect-and-normalize.js";
+import { intakeFromGitHub } from "./lib/evidence-intake.js";
 import { validateEvidence } from "./lib/validate-evidence.js";
 import {
   createJob,
@@ -40,7 +40,6 @@ import {
   readJsonBody,
   respondJson,
   randomState,
-  DATE_YYYY_MM_DD,
 } from "./server/helpers.js";
 import { authRoutes } from "./server/routes/auth.ts";
 import { jobsRoutes } from "./server/routes/jobs.ts";
@@ -159,7 +158,7 @@ function apiRoutesPlugin() {
           getSession,
           createJob,
           runInBackground,
-          collectAndNormalize,
+          intakeFromGitHub,
         })
       );
 
@@ -183,7 +182,7 @@ function apiRoutesPlugin() {
         periodicRoutes({
           getSessionIdFromRequest: getSessionId,
           getSession,
-          collectAndNormalize,
+          intakeFromGitHub,
         })
       );
     },


### PR DESCRIPTION
## Summary
- Introduces `lib/evidence-intake.ts` as the single seam for fetch → normalize → validate, with shared token and timeframe invariants.
- Updates collect route, periodic daily collection, CLI scripts, and server wiring to call `intakeFromGitHub` / `intakeFromRaw` instead of duplicating orchestration.
- Shrinks `lib/collect-and-normalize.ts` to a deprecated re-export alias and adds direct tests for the new interface.

Closes #140

## Test plan
- [x] `yarn test` (408 passing)
- [x] `yarn typecheck`
- [ ] Smoke test `POST /api/collect` with valid dates + session token
- [ ] Smoke test `POST /api/periodic/collect-day` for a single date
- [ ] Run `yarn collect --start 2025-01-01 --end 2025-01-31` and `yarn normalize` on output


Made with [Cursor](https://cursor.com)