### PR TITLE
Deepen evidence archive module (#142)

### DIFF
--- a/lib/evidence-archive/config.ts
+++ b/lib/evidence-archive/config.ts
@@ -1,0 +1,5 @@
+import { isDbConfigured } from "../db.js";
+
+export function isEvidenceArchiveConfigured(): boolean {
+  return isDbConfigured();
+}

--- a/lib/evidence-archive/index.ts
+++ b/lib/evidence-archive/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Evidence archive — shared seam for user-scoped dated evidence history.
+ *
+ * Snapshots and periodic summaries are adapters over this module's config,
+ * period, merge, and JSON utilities.
+ */
+
+export {
+  DATE_YYYY_MM_DD,
+  MONTH_YYYY_MM,
+  ARCHIVE_PERIOD_TYPES,
+  SNAPSHOT_PERIODS,
+  PERIODIC_PERIOD_TYPES,
+  toWeekKey,
+  weekStart,
+  weekEnd,
+  type ArchivePeriodType,
+  type SnapshotPeriod,
+} from "./period.js";
+
+export {
+  mergeEvidenceHistory,
+  filterSafeIds,
+  SNAPSHOT_ID_PATTERN,
+  type EvidenceHistoryRow,
+} from "./merge.js";
+
+export { tryParseJson, contributionCount } from "./json.js";
+
+export { isEvidenceArchiveConfigured } from "./config.js";
+
+export * as snapshots from "./snapshots-adapter.js";
+export * as periodic from "./periodic-adapter.js";
+
+export async function clearEvidenceArchiveForTests(): Promise<void> {
+  const [{ clearSnapshotStore }, { clearPeriodicStore }] = await Promise.all([
+    import("../snapshot-store.js"),
+    import("../periodic-store.js"),
+  ]);
+  await clearSnapshotStore();
+  await clearPeriodicStore();
+}

--- a/lib/evidence-archive/json.ts
+++ b/lib/evidence-archive/json.ts
@@ -1,0 +1,13 @@
+import type { Evidence } from "../../types/evidence.js";
+
+export function tryParseJson(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}
+
+export function contributionCount(evidence: Evidence): number {
+  return Array.isArray(evidence.contributions) ? evidence.contributions.length : 0;
+}

--- a/lib/evidence-archive/merge.ts
+++ b/lib/evidence-archive/merge.ts
@@ -1,0 +1,50 @@
+import type { Evidence, Contribution } from "../../types/evidence.js";
+
+export interface EvidenceHistoryRow {
+  evidence: Evidence;
+  start_date: string;
+  end_date: string;
+}
+
+export const SNAPSHOT_ID_PATTERN = /^snap_[a-z0-9_]+$/;
+
+export function filterSafeIds(ids: unknown[], pattern: RegExp): string[] {
+  return ids.filter((id): id is string => typeof id === "string" && pattern.test(id));
+}
+
+/**
+ * Merge dated evidence history rows into one combined evidence object.
+ * Deduplicates contributions by id, spans earliest→latest dates, and preserves
+ * role_context_optional from the first row.
+ */
+export function mergeEvidenceHistory(rows: EvidenceHistoryRow[]): Evidence | null {
+  if (rows.length === 0) return null;
+
+  const seen = new Set<string>();
+  const merged: Contribution[] = [];
+  let earliest = rows[0].start_date;
+  let latest = rows[0].end_date;
+  let roleContext: unknown = undefined;
+
+  for (const row of rows) {
+    const ev = row.evidence;
+    if (roleContext === undefined) roleContext = ev.role_context_optional;
+    if (row.start_date < earliest) earliest = row.start_date;
+    if (row.end_date > latest) latest = row.end_date;
+    for (const c of ev.contributions ?? []) {
+      if (!seen.has(c.id)) {
+        seen.add(c.id);
+        merged.push(c);
+      }
+    }
+  }
+
+  const combined: Evidence = {
+    timeframe: { start_date: earliest, end_date: latest },
+    contributions: merged,
+  };
+  if (roleContext !== undefined) {
+    combined.role_context_optional = roleContext;
+  }
+  return combined;
+}

--- a/lib/evidence-archive/period.ts
+++ b/lib/evidence-archive/period.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared period and calendar helpers for dated evidence history.
+ */
+
+export const DATE_YYYY_MM_DD = /^\d{4}-\d{2}-\d{2}$/;
+export const MONTH_YYYY_MM = /^\d{4}-\d{2}$/;
+
+export const ARCHIVE_PERIOD_TYPES = ["daily", "weekly", "monthly"] as const;
+export type ArchivePeriodType = (typeof ARCHIVE_PERIOD_TYPES)[number];
+export type SnapshotPeriod = ArchivePeriodType | "custom";
+
+export const SNAPSHOT_PERIODS = new Set<string>([...ARCHIVE_PERIOD_TYPES, "custom"]);
+export const PERIODIC_PERIOD_TYPES = new Set<string>(ARCHIVE_PERIOD_TYPES);
+
+const MS_PER_DAY = 86400000;
+const MS_PER_WEEK = 7 * MS_PER_DAY;
+
+/** Derive ISO week key "YYYY-WNN" from a date string "YYYY-MM-DD". */
+export function toWeekKey(date: string): string {
+  const d = new Date(date + "T12:00:00Z");
+  const dayOfWeek = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayOfWeek);
+  const isoYear = d.getUTCFullYear();
+  const jan4 = new Date(Date.UTC(isoYear, 0, 4));
+  const jan4DayOfWeek = jan4.getUTCDay() || 7;
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - jan4DayOfWeek + 1);
+  const weekNum = Math.floor((d.getTime() - week1Monday.getTime()) / MS_PER_WEEK) + 1;
+  return `${isoYear}-W${String(weekNum).padStart(2, "0")}`;
+}
+
+/** Derive the Monday (start) of the ISO week containing `date`. */
+export function weekStart(date: string): string {
+  const d = new Date(date + "T12:00:00Z");
+  const day = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() - (day - 1));
+  return d.toISOString().slice(0, 10);
+}
+
+/** Derive the Sunday (end) of the ISO week containing `date`. */
+export function weekEnd(date: string): string {
+  const d = new Date(date + "T12:00:00Z");
+  const day = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + (7 - day));
+  return d.toISOString().slice(0, 10);
+}

--- a/lib/evidence-archive/periodic-adapter.ts
+++ b/lib/evidence-archive/periodic-adapter.ts
@@ -1,0 +1,21 @@
+/**
+ * Periodic summary adapter over the evidence archive seam.
+ */
+export {
+  saveDailySummary,
+  saveWeeklyRollup,
+  saveMonthlyRollup,
+  getPeriodicSummary,
+  listPeriodicSummaries,
+  getDailySummariesForWeek,
+  getWeeklySummariesForMonth,
+  getMonthlySummariesForYear,
+  deletePeriodicSummary,
+  clearPeriodicStore,
+  isPeriodicStoreConfigured,
+  type PeriodType,
+  type PeriodicSummary,
+  type PeriodicSummaryWithEvidence,
+} from "../periodic-store.js";
+
+export { toWeekKey, weekStart, weekEnd } from "./period.js";

--- a/lib/evidence-archive/snapshots-adapter.ts
+++ b/lib/evidence-archive/snapshots-adapter.ts
@@ -1,0 +1,15 @@
+/**
+ * Snapshot adapter over the evidence archive seam.
+ */
+export {
+  saveSnapshot,
+  listSnapshots,
+  getSnapshot,
+  deleteSnapshot,
+  mergeSnapshots,
+  clearSnapshotStore,
+  isSnapshotStoreConfigured,
+  type Snapshot,
+  type SnapshotWithEvidence,
+  type SnapshotPeriod,
+} from "../snapshot-store.js";

--- a/lib/evidence-archive/types.ts
+++ b/lib/evidence-archive/types.ts
@@ -1,0 +1,19 @@
+export type {
+  SnapshotPeriod,
+  Snapshot,
+  SnapshotWithEvidence,
+} from "../snapshot-store.js";
+
+export type {
+  PeriodType,
+  PeriodicSummary as PeriodicSummaryRecord,
+  PeriodicSummaryWithEvidence,
+} from "../periodic-store.js";
+
+/** API/list shape after summary JSON is parsed for the client. */
+export type PeriodicSummary = Omit<
+  import("../periodic-store.js").PeriodicSummary,
+  "summary"
+> & { summary: unknown };
+
+export type { ArchivePeriodType } from "./period.js";

--- a/lib/periodic-store.ts
+++ b/lib/periodic-store.ts
@@ -16,10 +16,19 @@
  */
 
 import type { Evidence } from "../types/evidence.js";
-import { getPool, isDbConfigured } from "./db.js";
+import { getPool } from "./db.js";
+import { isEvidenceArchiveConfigured } from "./evidence-archive/config.js";
+import { contributionCount } from "./evidence-archive/json.js";
+import {
+  toWeekKey,
+  weekStart,
+  weekEnd,
+  type ArchivePeriodType,
+} from "./evidence-archive/period.js";
 import { generateId } from "./id.js";
 
-export type PeriodType = "daily" | "weekly" | "monthly";
+export type PeriodType = ArchivePeriodType;
+export { toWeekKey, weekStart, weekEnd } from "./evidence-archive/period.js";
 
 export interface PeriodicSummary {
   id: string;
@@ -42,43 +51,6 @@ export interface PeriodicSummaryWithEvidence extends PeriodicSummary {
   evidence: Evidence | null;
 }
 
-const MS_PER_DAY = 86400000;
-const MS_PER_WEEK = 7 * MS_PER_DAY;
-
-/** Derive ISO week key "YYYY-WNN" from a date string "YYYY-MM-DD". */
-export function toWeekKey(date: string): string {
-  const d = new Date(date + "T12:00:00Z"); // noon UTC avoids DST edge cases
-  // Move to the Thursday of this week (ISO rule: week belongs to the year of its Thursday)
-  const dayOfWeek = d.getUTCDay() || 7; // Sun=0 → 7
-  d.setUTCDate(d.getUTCDate() + 4 - dayOfWeek);
-  // Now d is Thursday of the ISO week; its year is the ISO year
-  const isoYear = d.getUTCFullYear();
-  // Find the Monday of ISO week 1: the Monday of the week containing Jan 4
-  const jan4 = new Date(Date.UTC(isoYear, 0, 4)); // Jan 4 is always in week 1
-  const jan4DayOfWeek = jan4.getUTCDay() || 7;
-  const week1Monday = new Date(jan4);
-  week1Monday.setUTCDate(jan4.getUTCDate() - jan4DayOfWeek + 1);
-  // Use Math.floor: d is at noon, week1Monday at midnight — floor avoids rounding across midnight
-  const weekNum = Math.floor((d.getTime() - week1Monday.getTime()) / MS_PER_WEEK) + 1;
-  return `${isoYear}-W${String(weekNum).padStart(2, "0")}`;
-}
-
-/** Derive the Monday (start) of the ISO week containing `date`. */
-export function weekStart(date: string): string {
-  const d = new Date(date + "T12:00:00Z");
-  const day = d.getUTCDay() || 7; // Sun=0 → 7
-  d.setUTCDate(d.getUTCDate() - (day - 1));
-  return d.toISOString().slice(0, 10);
-}
-
-/** Derive the Sunday (end) of the ISO week containing `date`. */
-export function weekEnd(date: string): string {
-  const d = new Date(date + "T12:00:00Z");
-  const day = d.getUTCDay() || 7;
-  d.setUTCDate(d.getUTCDate() + (7 - day));
-  return d.toISOString().slice(0, 10);
-}
-
 /**
  * Save or replace the daily summary for a calendar date.
  * If a summary already exists for this user+date it is overwritten (upsert).
@@ -92,9 +64,7 @@ export async function saveDailySummary(
   const db = await getPool();
   const id = generateId("pday");
   const createdAt = new Date().toISOString();
-  const contributionCount = Array.isArray(evidence.contributions)
-    ? evidence.contributions.length
-    : 0;
+  const count = contributionCount(evidence);
 
   await db.query(
     `INSERT INTO periodic_summaries
@@ -114,7 +84,7 @@ export async function saveDailySummary(
       date,            // period_key
       date,            // start_date
       date,            // end_date
-      contributionCount,
+      count,
       summary,
       JSON.stringify(evidence),
       createdAt,
@@ -357,8 +327,9 @@ export async function deletePeriodicSummary(
   return (result.rowCount ?? 0) > 0;
 }
 
+/** @deprecated Use isEvidenceArchiveConfigured from lib/evidence-archive. */
 export function isPeriodicStoreConfigured(): boolean {
-  return isDbConfigured();
+  return isEvidenceArchiveConfigured();
 }
 
 /** Clear all rows (for tests). */

--- a/lib/snapshot-store.ts
+++ b/lib/snapshot-store.ts
@@ -11,11 +11,19 @@
  * Throws on first use if DATABASE_URL is not set.
  */
 
-import type { Evidence, Contribution } from "../types/evidence.js";
-import { getPool, isDbConfigured } from "./db.js";
+import type { Evidence } from "../types/evidence.js";
+import { getPool } from "./db.js";
+import {
+  filterSafeIds,
+  mergeEvidenceHistory,
+  SNAPSHOT_ID_PATTERN,
+} from "./evidence-archive/merge.js";
+import { isEvidenceArchiveConfigured } from "./evidence-archive/config.js";
+import { contributionCount } from "./evidence-archive/json.js";
+import type { SnapshotPeriod } from "./evidence-archive/period.js";
 import { generateId } from "./id.js";
 
-export type SnapshotPeriod = "daily" | "weekly" | "monthly" | "custom";
+export type { SnapshotPeriod } from "./evidence-archive/period.js";
 
 export interface Snapshot {
   id: string;
@@ -47,9 +55,7 @@ export async function saveSnapshot(
   const db = await getPool();
   const id = generateId("snap");
   const createdAt = new Date().toISOString();
-  const contributionCount = Array.isArray(evidence.contributions)
-    ? evidence.contributions.length
-    : 0;
+  const count = contributionCount(evidence);
 
   await db.query(
     `INSERT INTO contribution_snapshots
@@ -62,7 +68,7 @@ export async function saveSnapshot(
       startDate,
       endDate,
       label ?? null,
-      contributionCount,
+      count,
       JSON.stringify(evidence),
       createdAt,
     ]
@@ -132,14 +138,10 @@ export async function mergeSnapshots(
   ids: string[],
   userLogin: string
 ): Promise<Evidence | null> {
-  if (ids.length === 0) return null;
-  // Validate id format to prevent passing unexpected values to the DB
-  const SAFE_ID_RE = /^snap_[a-z0-9_]+$/;
-  const safeIds = ids.filter((id) => typeof id === "string" && SAFE_ID_RE.test(id));
+  const safeIds = filterSafeIds(ids, SNAPSHOT_ID_PATTERN);
   if (safeIds.length === 0) return null;
   const db = await getPool();
 
-  // Use ANY($2::text[]) to pass the ids array as a single parameter
   const result = await db.query<{ evidence: Evidence; start_date: string; end_date: string }>(
     `SELECT evidence, start_date, end_date
      FROM contribution_snapshots
@@ -148,39 +150,12 @@ export async function mergeSnapshots(
     [userLogin, safeIds]
   );
 
-  if (result.rows.length === 0) return null;
-
-  const seen = new Set<string>();
-  const merged: Contribution[] = [];
-  let earliest = result.rows[0].start_date;
-  let latest = result.rows[0].end_date;
-  let roleContext: unknown = undefined;
-
-  for (const row of result.rows) {
-    const ev = row.evidence;
-    if (roleContext === undefined) roleContext = ev.role_context_optional;
-    if (row.start_date < earliest) earliest = row.start_date;
-    if (row.end_date > latest) latest = row.end_date;
-    for (const c of ev.contributions ?? []) {
-      if (!seen.has(c.id)) {
-        seen.add(c.id);
-        merged.push(c);
-      }
-    }
-  }
-
-  const combined: Evidence = {
-    timeframe: { start_date: earliest, end_date: latest },
-    contributions: merged,
-  };
-  if (roleContext !== undefined) {
-    combined.role_context_optional = roleContext;
-  }
-  return combined;
+  return mergeEvidenceHistory(result.rows);
 }
 
+/** @deprecated Use isEvidenceArchiveConfigured from lib/evidence-archive. */
 export function isSnapshotStoreConfigured(): boolean {
-  return isDbConfigured();
+  return isEvidenceArchiveConfigured();
 }
 
 /** Reset the store (for tests). Removes all rows. */

--- a/server/routes/evidence-archive-helpers.ts
+++ b/server/routes/evidence-archive-helpers.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared route helpers for evidence archive endpoints (snapshots + periodic).
+ */
+
+import type { IncomingMessage, ServerResponse } from "http";
+import type { SessionData } from "../../lib/session-store.js";
+import { respondJson } from "../helpers.js";
+
+export function createRequireLogin(
+  req: IncomingMessage,
+  res: ServerResponse,
+  getSessionIdFromRequest: (req: IncomingMessage) => string | null,
+  getSession: (id: string) => SessionData | undefined
+): () => string | null {
+  return () => {
+    const sessId = getSessionIdFromRequest(req);
+    const session = sessId ? getSession(sessId) : undefined;
+    if (!session?.login) {
+      respondJson(res, 401, { error: "Login required" });
+      return null;
+    }
+    return session.login;
+  };
+}
+
+export function requireEvidenceArchiveConfigured(
+  res: ServerResponse,
+  configured: boolean,
+  featureLabel: "Snapshot store" | "Periodic store"
+): boolean {
+  if (configured) return true;
+  respondJson(res, 503, {
+    error: `${featureLabel} not configured (DATABASE_URL missing)`,
+  });
+  return false;
+}
+
+export async function readJsonBodyOrRespond400(
+  req: IncomingMessage,
+  res: ServerResponse,
+  readJsonBody: (req: IncomingMessage) => Promise<object>
+): Promise<Record<string, unknown> | null> {
+  try {
+    return (await readJsonBody(req)) as Record<string, unknown>;
+  } catch {
+    respondJson(res, 400, { error: "Invalid JSON body" });
+    return null;
+  }
+}

--- a/server/routes/periodic.ts
+++ b/server/routes/periodic.ts
@@ -21,8 +21,20 @@ import type {
   PeriodicSummaryWithEvidence,
   PeriodType,
 } from "../../lib/periodic-store.js";
-import { weekStart, weekEnd } from "../../lib/periodic-store.js";
+import {
+  DATE_YYYY_MM_DD,
+  MONTH_YYYY_MM,
+  PERIODIC_PERIOD_TYPES,
+  weekStart,
+  weekEnd,
+} from "../../lib/evidence-archive/period.js";
+import { tryParseJson } from "../../lib/evidence-archive/json.js";
 import { readJsonBody as defaultReadJsonBody, respondJson } from "../helpers.js";
+import {
+  createRequireLogin,
+  readJsonBodyOrRespond400,
+  requireEvidenceArchiveConfigured,
+} from "./evidence-archive-helpers.js";
 
 export interface PeriodicRoutesOptions {
   /** Injected in tests; defaults to streaming JSON from the request. */
@@ -47,9 +59,6 @@ export interface PeriodicRoutesOptions {
 
 type Next = () => void;
 
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const MONTH_RE = /^\d{4}-\d{2}$/;
-const VALID_PERIOD_TYPES = new Set(["daily", "weekly", "monthly"]);
 const DEFAULT_SUMMARIES_LIMIT = 90;
 const MAX_SUMMARIES_LIMIT = 365;
 
@@ -90,7 +99,7 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
     }
 
     const [store, pipeline] = await Promise.all([
-      import("../../lib/periodic-store.js"),
+      import("../../lib/evidence-archive/periodic-adapter.js"),
       import("../../lib/run-periodic-pipeline.js"),
     ]);
     return {
@@ -109,27 +118,28 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
     };
   }
 
-  function makeRequireLogin(req: IncomingMessage, res: ServerResponse): () => string | null {
-    return () => {
-      const sessId = getSessionIdFromRequest(req);
-      const session = sessId ? getSession(sessId) : undefined;
-      if (!session?.login) {
-        respondJson(res, 401, { error: "Login required" });
-        return null;
-      }
-      return session.login;
-    };
-  }
-
   return async function periodicMiddleware(
     req: IncomingMessage,
     res: ServerResponse,
     next: Next
   ): Promise<void> {
-    const requireLogin = makeRequireLogin(req, res);
+    const requireLogin = createRequireLogin(
+      req,
+      res,
+      getSessionIdFromRequest,
+      getSession
+    );
     const rawPath = (req.url?.split("?")[0] || "").replace(/^\/+/, "") || "";
     const queryString = req.url?.split("?")[1] ?? "";
     const params = new URLSearchParams(queryString);
+
+    function ensureConfigured(isConfigured: () => boolean): boolean {
+      return requireEvidenceArchiveConfigured(
+        res,
+        isConfigured(),
+        "Periodic store"
+      );
+    }
 
     // ── POST /collect-day ──────────────────────────────────────────────────
     if (rawPath === "collect-day" && req.method === "POST") {
@@ -137,29 +147,19 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
       if (!userLogin) return;
 
       const store = await getStore();
-      if (!store.isPeriodicStoreConfigured()) {
-        respondJson(res, 503, { error: "Periodic store not configured (DATABASE_URL missing)" });
-        return;
-      }
+      if (!ensureConfigured(store.isPeriodicStoreConfigured)) return;
 
-      let body: Record<string, unknown>;
-      try {
-        body = (await readJsonBody(req)) as Record<string, unknown>;
-      } catch {
-        respondJson(res, 400, { error: "Invalid JSON body" });
-        return;
-      }
+      const body = await readJsonBodyOrRespond400(req, res, readJsonBody);
+      if (!body) return;
 
-      // Default to today (UTC)
       const date = (body.date as string | undefined) ??
         new Date().toISOString().slice(0, 10);
 
-      if (!DATE_RE.test(date)) {
+      if (!DATE_YYYY_MM_DD.test(date)) {
         respondJson(res, 400, { error: "date must be YYYY-MM-DD" });
         return;
       }
 
-      // Resolve token: body > session
       const sessId = getSessionIdFromRequest(req);
       const session = sessId ? getSession(sessId) : undefined;
       const token = (body.token as string | undefined) ?? session?.access_token;
@@ -172,13 +172,11 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
         const evidence = await collectAndNormalize({ token, start_date: date, end_date: date });
         const summaryJson = await store.runDailySummary(evidence);
         const id = await store.saveDailySummary(userLogin, date, evidence, summaryJson);
-        let parsedSummary: unknown = summaryJson;
-        try { parsedSummary = JSON.parse(summaryJson); } catch { /* return raw */ }
         respondJson(res, 201, {
           id,
           date,
           contribution_count: evidence.contributions.length,
-          summary: parsedSummary,
+          summary: tryParseJson(summaryJson),
         });
       } catch (e) {
         const err = e as Error;
@@ -193,25 +191,16 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
       if (!userLogin) return;
 
       const store = await getStore();
-      if (!store.isPeriodicStoreConfigured()) {
-        respondJson(res, 503, { error: "Periodic store not configured (DATABASE_URL missing)" });
-        return;
-      }
+      if (!ensureConfigured(store.isPeriodicStoreConfigured)) return;
 
-      let body: Record<string, unknown>;
-      try {
-        body = (await readJsonBody(req)) as Record<string, unknown>;
-      } catch {
-        respondJson(res, 400, { error: "Invalid JSON body" });
-        return;
-      }
+      const body = await readJsonBodyOrRespond400(req, res, readJsonBody);
+      if (!body) return;
 
-      // Default to the current week's Monday
       const rawDate = (body.week_start as string | undefined) ??
         new Date().toISOString().slice(0, 10);
       const ws = weekStart(rawDate);
 
-      if (!DATE_RE.test(ws)) {
+      if (!DATE_YYYY_MM_DD.test(ws)) {
         respondJson(res, 400, { error: "week_start must be YYYY-MM-DD" });
         return;
       }
@@ -230,15 +219,13 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
         const childIds = dailies.map((d) => d.id);
         const id = await store.saveWeeklyRollup(userLogin, ws, childIds, rollupJson, totalContributions);
 
-        let parsedSummary: unknown = rollupJson;
-        try { parsedSummary = JSON.parse(rollupJson); } catch { /* return raw */ }
         respondJson(res, 201, {
           id,
           week_start: ws,
           week_end: we,
           days_covered: dailies.length,
           total_contributions: totalContributions,
-          summary: parsedSummary,
+          summary: tryParseJson(rollupJson),
         });
       } catch (e) {
         const err = e as Error;
@@ -253,24 +240,15 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
       if (!userLogin) return;
 
       const store = await getStore();
-      if (!store.isPeriodicStoreConfigured()) {
-        respondJson(res, 503, { error: "Periodic store not configured (DATABASE_URL missing)" });
-        return;
-      }
+      if (!ensureConfigured(store.isPeriodicStoreConfigured)) return;
 
-      let body: Record<string, unknown>;
-      try {
-        body = (await readJsonBody(req)) as Record<string, unknown>;
-      } catch {
-        respondJson(res, 400, { error: "Invalid JSON body" });
-        return;
-      }
+      const body = await readJsonBodyOrRespond400(req, res, readJsonBody);
+      if (!body) return;
 
-      // Default to current month
       const month = (body.month as string | undefined) ??
         new Date().toISOString().slice(0, 7);
 
-      if (!MONTH_RE.test(month)) {
+      if (!MONTH_YYYY_MM.test(month)) {
         respondJson(res, 400, { error: "month must be YYYY-MM" });
         return;
       }
@@ -288,14 +266,12 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
         const childIds = weeklies.map((w) => w.id);
         const id = await store.saveMonthlyRollup(userLogin, month, childIds, rollupJson, totalContributions);
 
-        let parsedSummary: unknown = rollupJson;
-        try { parsedSummary = JSON.parse(rollupJson); } catch { /* return raw */ }
         respondJson(res, 201, {
           id,
           month,
           weeks_covered: weeklies.length,
           total_contributions: totalContributions,
-          summary: parsedSummary,
+          summary: tryParseJson(rollupJson),
         });
       } catch (e) {
         const err = e as Error;
@@ -310,21 +286,17 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
       if (!userLogin) return;
 
       const store = await getStore();
-      if (!store.isPeriodicStoreConfigured()) {
-        respondJson(res, 503, { error: "Periodic store not configured (DATABASE_URL missing)" });
-        return;
-      }
+      if (!ensureConfigured(store.isPeriodicStoreConfigured)) return;
 
       const typeParam = params.get("type");
       const limitParam = params.get("limit");
-      const periodType = typeParam && VALID_PERIOD_TYPES.has(typeParam)
+      const periodType = typeParam && PERIODIC_PERIOD_TYPES.has(typeParam)
         ? (typeParam as PeriodType)
         : undefined;
       const limit = limitParam ? Math.min(Math.max(parseInt(limitParam), 1), MAX_SUMMARIES_LIMIT) : DEFAULT_SUMMARIES_LIMIT;
 
       try {
         const summaries = await store.listPeriodicSummaries(userLogin, periodType, limit);
-        // Parse the JSON summary string for easier frontend consumption
         const parsed = summaries.map((s) => ({
           ...s,
           summary: tryParseJson(s.summary),
@@ -348,10 +320,7 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
         if (!userLogin) return;
 
         const store = await getStore();
-        if (!store.isPeriodicStoreConfigured()) {
-          respondJson(res, 503, { error: "Periodic store not configured (DATABASE_URL missing)" });
-          return;
-        }
+        if (!ensureConfigured(store.isPeriodicStoreConfigured)) return;
 
         try {
           const summary = await store.getPeriodicSummary(id, userLogin);
@@ -376,10 +345,7 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
         if (!userLogin) return;
 
         const store = await getStore();
-        if (!store.isPeriodicStoreConfigured()) {
-          respondJson(res, 503, { error: "Periodic store not configured (DATABASE_URL missing)" });
-          return;
-        }
+        if (!ensureConfigured(store.isPeriodicStoreConfigured)) return;
 
         try {
           const deleted = await store.deletePeriodicSummary(id, userLogin);
@@ -398,8 +364,4 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
 
     next();
   };
-}
-
-function tryParseJson(s: string): unknown {
-  try { return JSON.parse(s); } catch { return s; }
 }

--- a/server/routes/snapshots.ts
+++ b/server/routes/snapshots.ts
@@ -15,7 +15,16 @@ import type {
   SnapshotWithEvidence,
   SnapshotPeriod,
 } from "../../lib/snapshot-store.js";
+import {
+  DATE_YYYY_MM_DD,
+  SNAPSHOT_PERIODS,
+} from "../../lib/evidence-archive/period.js";
 import { readJsonBody as defaultReadJsonBody, respondJson } from "../helpers.js";
+import {
+  createRequireLogin,
+  readJsonBodyOrRespond400,
+  requireEvidenceArchiveConfigured,
+} from "./evidence-archive-helpers.js";
 
 export interface SnapshotsRoutesOptions {
   /** Injected in tests; defaults to streaming JSON from the request. */
@@ -40,14 +49,8 @@ export interface SnapshotsRoutesOptions {
 
 type Next = () => void;
 
-const VALID_PERIODS = new Set<string>(["daily", "weekly", "monthly", "custom"]);
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
 export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
-  const {
-    getSessionIdFromRequest,
-    getSession,
-  } = options;
+  const { getSessionIdFromRequest, getSession } = options;
   const readJsonBody = options.readJsonBody ?? defaultReadJsonBody;
 
   return async function snapshotsMiddleware(
@@ -56,9 +59,13 @@ export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
     next: Next
   ): Promise<void> {
     const rawPath = (req.url?.split("?")[0] || "").replace(/^\/+/, "") || "";
+    const requireLogin = createRequireLogin(
+      req,
+      res,
+      getSessionIdFromRequest,
+      getSession
+    );
 
-    // Resolve the real store functions lazily (so tests can inject mocks without
-    // importing the real module at test time).
     async function getStore() {
       if (
         options.saveSnapshot &&
@@ -77,7 +84,7 @@ export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
           isSnapshotStoreConfigured: options.isSnapshotStoreConfigured,
         };
       }
-      const store = await import("../../lib/snapshot-store.js");
+      const store = await import("../../lib/evidence-archive/snapshots-adapter.js");
       return {
         saveSnapshot: store.saveSnapshot,
         listSnapshots: store.listSnapshots,
@@ -88,15 +95,12 @@ export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
       };
     }
 
-    // Helper: authenticate and return the user's login, or respond 401.
-    function requireLogin(): string | null {
-      const sessId = getSessionIdFromRequest(req);
-      const session = sessId ? getSession(sessId) : undefined;
-      if (!session?.login) {
-        respondJson(res, 401, { error: "Login required" });
-        return null;
-      }
-      return session.login;
+    function ensureConfigured(isConfigured: () => boolean): boolean {
+      return requireEvidenceArchiveConfigured(
+        res,
+        isConfigured(),
+        "Snapshot store"
+      );
     }
 
     // POST /merge — merge multiple snapshots into combined evidence
@@ -105,18 +109,10 @@ export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
       if (!userLogin) return;
 
       const store = await getStore();
-      if (!store.isSnapshotStoreConfigured()) {
-        respondJson(res, 503, { error: "Snapshot store not configured (DATABASE_URL missing)" });
-        return;
-      }
+      if (!ensureConfigured(store.isSnapshotStoreConfigured)) return;
 
-      let body: Record<string, unknown>;
-      try {
-        body = (await readJsonBody(req)) as Record<string, unknown>;
-      } catch {
-        respondJson(res, 400, { error: "Invalid JSON body" });
-        return;
-      }
+      const body = await readJsonBodyOrRespond400(req, res, readJsonBody);
+      if (!body) return;
 
       const ids = body.ids;
       if (!Array.isArray(ids) || ids.length === 0 || ids.some((id) => typeof id !== "string")) {
@@ -144,10 +140,7 @@ export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
       if (!userLogin) return;
 
       const store = await getStore();
-      if (!store.isSnapshotStoreConfigured()) {
-        respondJson(res, 503, { error: "Snapshot store not configured (DATABASE_URL missing)" });
-        return;
-      }
+      if (!ensureConfigured(store.isSnapshotStoreConfigured)) return;
 
       try {
         const snapshots = await store.listSnapshots(userLogin);
@@ -165,18 +158,10 @@ export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
       if (!userLogin) return;
 
       const store = await getStore();
-      if (!store.isSnapshotStoreConfigured()) {
-        respondJson(res, 503, { error: "Snapshot store not configured (DATABASE_URL missing)" });
-        return;
-      }
+      if (!ensureConfigured(store.isSnapshotStoreConfigured)) return;
 
-      let body: Record<string, unknown>;
-      try {
-        body = (await readJsonBody(req)) as Record<string, unknown>;
-      } catch {
-        respondJson(res, 400, { error: "Invalid JSON body" });
-        return;
-      }
+      const body = await readJsonBodyOrRespond400(req, res, readJsonBody);
+      if (!body) return;
 
       const { period, start_date, end_date, evidence, label } = body as {
         period?: string;
@@ -186,15 +171,15 @@ export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
         label?: string;
       };
 
-      if (!period || !VALID_PERIODS.has(period)) {
+      if (!period || !SNAPSHOT_PERIODS.has(period)) {
         respondJson(res, 400, { error: "period must be one of: daily, weekly, monthly, custom" });
         return;
       }
-      if (!start_date || !DATE_RE.test(start_date)) {
+      if (!start_date || !DATE_YYYY_MM_DD.test(start_date)) {
         respondJson(res, 400, { error: "start_date must be YYYY-MM-DD" });
         return;
       }
-      if (!end_date || !DATE_RE.test(end_date)) {
+      if (!end_date || !DATE_YYYY_MM_DD.test(end_date)) {
         respondJson(res, 400, { error: "end_date must be YYYY-MM-DD" });
         return;
       }
@@ -237,10 +222,7 @@ export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
         if (!userLogin) return;
 
         const store = await getStore();
-        if (!store.isSnapshotStoreConfigured()) {
-          respondJson(res, 503, { error: "Snapshot store not configured (DATABASE_URL missing)" });
-          return;
-        }
+        if (!ensureConfigured(store.isSnapshotStoreConfigured)) return;
 
         try {
           const snapshot = await store.getSnapshot(snapshotId, userLogin);
@@ -262,10 +244,7 @@ export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
         if (!userLogin) return;
 
         const store = await getStore();
-        if (!store.isSnapshotStoreConfigured()) {
-          respondJson(res, 503, { error: "Snapshot store not configured (DATABASE_URL missing)" });
-          return;
-        }
+        if (!ensureConfigured(store.isSnapshotStoreConfigured)) return;
 
         try {
           const deleted = await store.deleteSnapshot(snapshotId, userLogin);

--- a/src/hooks/usePeriodic.ts
+++ b/src/hooks/usePeriodic.ts
@@ -1,20 +1,9 @@
 import { useState, useCallback, useEffect } from "react";
 import type { AuthUser } from "./useAuth.js";
 
-export type PeriodType = "daily" | "weekly" | "monthly";
+import type { PeriodicSummary, PeriodType } from "../../lib/evidence-archive/types.js";
 
-export interface PeriodicSummary {
-  id: string;
-  user_login: string;
-  period_type: PeriodType;
-  period_key: string;
-  start_date: string;
-  end_date: string;
-  contribution_count: number;
-  summary: unknown; // parsed JSON — shape varies by period_type
-  child_ids: string[] | null;
-  created_at: string;
-}
+export type { PeriodicSummary, PeriodType };
 
 interface DailySummaryResult {
   id: string;

--- a/src/hooks/useSnapshots.ts
+++ b/src/hooks/useSnapshots.ts
@@ -1,18 +1,9 @@
 import { useState, useCallback, useEffect } from "react";
 import type { AuthUser } from "./useAuth.js";
 
-export type SnapshotPeriod = "daily" | "weekly" | "monthly" | "custom";
+import type { Snapshot, SnapshotPeriod } from "../../lib/evidence-archive/types.js";
 
-export interface Snapshot {
-  id: string;
-  user_login: string;
-  period: SnapshotPeriod;
-  start_date: string;
-  end_date: string;
-  label: string | null;
-  contribution_count: number;
-  created_at: string;
-}
+export type { Snapshot, SnapshotPeriod };
 
 interface UseSnapshotsOptions {
   user: AuthUser | null;

--- a/test/evidence-archive.test.js
+++ b/test/evidence-archive.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  DATE_YYYY_MM_DD,
+  MONTH_YYYY_MM,
+  SNAPSHOT_PERIODS,
+  PERIODIC_PERIOD_TYPES,
+  toWeekKey,
+  weekStart,
+  weekEnd,
+  isEvidenceArchiveConfigured,
+  mergeEvidenceHistory,
+  filterSafeIds,
+  SNAPSHOT_ID_PATTERN,
+  tryParseJson,
+  contributionCount,
+} from "../lib/evidence-archive/index.ts";
+
+const EVIDENCE_A = {
+  timeframe: { start_date: "2025-01-01", end_date: "2025-01-07" },
+  contributions: [
+    { id: "repo#1", type: "pull_request", title: "PR one", url: "https://github.com/org/repo/pull/1", repo: "org/repo" },
+    { id: "repo#2", type: "review", title: "Review one", url: "https://github.com/org/repo/pull/2", repo: "org/repo" },
+  ],
+};
+
+const EVIDENCE_B = {
+  timeframe: { start_date: "2025-01-08", end_date: "2025-01-14" },
+  contributions: [
+    { id: "repo#3", type: "pull_request", title: "PR two", url: "https://github.com/org/repo/pull/3", repo: "org/repo" },
+    { id: "repo#2", type: "review", title: "Review one (dup)", url: "https://github.com/org/repo/pull/2", repo: "org/repo" },
+  ],
+};
+
+describe("evidence-archive – period", () => {
+  it("validates calendar dates", () => {
+    expect(DATE_YYYY_MM_DD.test("2025-01-15")).toBe(true);
+    expect(DATE_YYYY_MM_DD.test("2025-1-15")).toBe(false);
+  });
+
+  it("validates month keys", () => {
+    expect(MONTH_YYYY_MM.test("2025-01")).toBe(true);
+    expect(MONTH_YYYY_MM.test("2025-1")).toBe(false);
+  });
+
+  it("includes custom in snapshot periods but not periodic periods", () => {
+    expect(SNAPSHOT_PERIODS.has("custom")).toBe(true);
+    expect(PERIODIC_PERIOD_TYPES.has("custom")).toBe(false);
+  });
+
+  it("toWeekKey returns ISO week for known dates", () => {
+    expect(toWeekKey("2025-01-06")).toBe("2025-W02");
+    expect(toWeekKey("2024-12-30")).toBe("2025-W01");
+  });
+
+  it("weekStart and weekEnd bound the ISO week", () => {
+    expect(weekStart("2025-01-15")).toBe("2025-01-13");
+    expect(weekEnd("2025-01-15")).toBe("2025-01-19");
+  });
+});
+
+describe("evidence-archive – merge", () => {
+  it("mergeEvidenceHistory combines rows and deduplicates contributions", () => {
+    const merged = mergeEvidenceHistory([
+      { evidence: EVIDENCE_A, start_date: "2025-01-01", end_date: "2025-01-07" },
+      { evidence: EVIDENCE_B, start_date: "2025-01-08", end_date: "2025-01-14" },
+    ]);
+    expect(merged.timeframe.start_date).toBe("2025-01-01");
+    expect(merged.timeframe.end_date).toBe("2025-01-14");
+    expect(merged.contributions).toHaveLength(3);
+  });
+
+  it("mergeEvidenceHistory returns null for empty input", () => {
+    expect(mergeEvidenceHistory([])).toBeNull();
+  });
+
+  it("mergeEvidenceHistory preserves role_context_optional from first row", () => {
+    const merged = mergeEvidenceHistory([
+      {
+        evidence: { ...EVIDENCE_A, role_context_optional: { title: "Engineer" } },
+        start_date: "2025-01-01",
+        end_date: "2025-01-07",
+      },
+      { evidence: EVIDENCE_B, start_date: "2025-01-08", end_date: "2025-01-14" },
+    ]);
+    expect(merged.role_context_optional).toEqual({ title: "Engineer" });
+  });
+
+  it("filterSafeIds rejects invalid snapshot ids", () => {
+    expect(filterSafeIds(["snap_ok", "bad id", 1], SNAPSHOT_ID_PATTERN)).toEqual(["snap_ok"]);
+  });
+});
+
+describe("evidence-archive – json", () => {
+  it("tryParseJson parses valid JSON and returns raw string on failure", () => {
+    expect(tryParseJson('{"a":1}')).toEqual({ a: 1 });
+    expect(tryParseJson("not json")).toBe("not json");
+  });
+
+  it("contributionCount counts evidence contributions safely", () => {
+    expect(contributionCount(EVIDENCE_A)).toBe(2);
+    expect(contributionCount({ timeframe: EVIDENCE_A.timeframe, contributions: null })).toBe(0);
+  });
+});
+
+describe("evidence-archive – config", () => {
+  it("isEvidenceArchiveConfigured mirrors DATABASE_URL", () => {
+    const original = process.env.DATABASE_URL;
+    if (original) {
+      expect(isEvidenceArchiveConfigured()).toBe(true);
+    } else {
+      expect(isEvidenceArchiveConfigured()).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces `lib/evidence-archive/` as the shared seam for dated evidence history: config, period/calendar helpers, merge rules, JSON utilities, and snapshot/periodic adapters.
- Refactors snapshot and periodic stores to delegate merge logic, contribution counting, and configuration checks through the archive module.
- Deduplicates snapshot/periodic route auth, DATABASE_URL gating, and JSON body parsing via `server/routes/evidence-archive-helpers.ts`; frontend hooks now import shared types from the archive module.

Closes #142

## Test plan
- [x] `yarn typecheck`
- [x] `yarn test --run` (410 tests)
- [x] `yarn build`
- [x] New unit tests in `test/evidence-archive.test.js` for merge, period, config, and JSON helpers


Made with [Cursor](https://cursor.com)