### PR TITLE
architecture: collapse the narrative model runner

### DIFF
--- a/lib/narrative-model-runner.ts
+++ b/lib/narrative-model-runner.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared narrative model runner: OpenRouter client setup, prompt execution,
+ * JSON extraction, model defaults, and PostHog tracing for LLM calls.
+ */
+
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import OpenAI from "openai";
+import { OpenAI as PostHogOpenAI } from "@posthog/ai/openai";
+import { PostHog } from "posthog-node";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROMPTS_DIR = join(__dirname, "..", "prompts");
+
+export const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
+
+export function loadPrompt(name: string): string {
+  return readFileSync(join(PROMPTS_DIR, name), "utf8").trim();
+}
+
+/** Default model ids for free and premium (OpenRouter). */
+export function getDefaultModels(): { free: string; premium: string } {
+  return {
+    free: process.env.LLM_MODEL ?? "anthropic/claude-3-haiku",
+    premium: process.env.PREMIUM_LLM_MODEL ?? "anthropic/claude-haiku-4.5",
+  };
+}
+
+export function resolveModel(options: { model?: string; premium?: boolean } = {}): string {
+  const { model, premium = false } = options;
+  return model ?? getDefaultModels()[premium ? "premium" : "free"];
+}
+
+/** Pull first {...} from LLM response text and parse as JSON. */
+export function extractJson(text: string): unknown {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}") + 1;
+  if (start === -1 || end === 0) throw new Error("No JSON object in response");
+  return JSON.parse(text.slice(start, end));
+}
+
+export interface NarrativeClient {
+  openai: OpenAI;
+  posthogOpts: Record<string, string | boolean>;
+  shutdown: () => Promise<void>;
+}
+
+export interface CreateNarrativeClientOptions {
+  apiKey: string;
+  baseURL?: string;
+  posthogTraceId?: string;
+  posthogDistinctId?: string;
+}
+
+export function createNarrativeClient({
+  apiKey,
+  baseURL,
+  posthogTraceId,
+  posthogDistinctId,
+}: CreateNarrativeClientOptions): NarrativeClient {
+  const posthogApiKey = process.env.POSTHOG_API_KEY;
+  const posthogClient = posthogApiKey
+    ? new PostHog(posthogApiKey, { host: process.env.POSTHOG_HOST || "https://us.i.posthog.com" })
+    : null;
+
+  const clientOpts: ConstructorParameters<typeof OpenAI>[0] = { apiKey };
+  if (baseURL) {
+    clientOpts.baseURL = baseURL;
+    clientOpts.defaultHeaders = {
+      "HTTP-Referer": "https://annualreview.dev",
+      "X-Title": "AnnualReview.dev",
+    };
+  }
+
+  const openai: OpenAI = posthogClient
+    ? new PostHogOpenAI({
+        ...clientOpts,
+        apiKey,
+        posthog: posthogClient,
+      } as ConstructorParameters<typeof PostHogOpenAI>[0]) as unknown as OpenAI
+    : new OpenAI(clientOpts);
+
+  const posthogOpts: Record<string, string | boolean> = {};
+  if (posthogTraceId != null) posthogOpts.posthogTraceId = posthogTraceId;
+  if (posthogDistinctId != null) posthogOpts.posthogDistinctId = posthogDistinctId;
+  if (posthogClient) posthogOpts.posthogCaptureImmediate = true;
+  if (posthogClient && baseURL?.includes("openrouter.ai")) posthogOpts.posthogProviderOverride = "openrouter";
+
+  return {
+    openai,
+    posthogOpts,
+    shutdown: () => (posthogClient ? posthogClient.shutdown() : Promise.resolve()),
+  };
+}
+
+export interface NarrativeCompletionOptions {
+  client: NarrativeClient;
+  model: string;
+  promptContent: string;
+  inputJson: string;
+  systemPrompt?: string;
+  stepLabel?: string;
+  emptyContentError?: string;
+  /** When false, rethrow extractJson errors without step wrapping. Default true. */
+  wrapJsonErrors?: boolean;
+}
+
+export async function runNarrativeCompletion({
+  client,
+  model,
+  promptContent,
+  inputJson,
+  systemPrompt,
+  stepLabel = "narrative prompt",
+  emptyContentError,
+  wrapJsonErrors = true,
+}: NarrativeCompletionOptions): Promise<{ raw: string; parsed: unknown }> {
+  const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [];
+  if (systemPrompt) {
+    messages.push({ role: "system", content: systemPrompt });
+  }
+  messages.push({ role: "user", content: `${promptContent}\n\nINPUT JSON:\n${inputJson}` });
+
+  const completion = await client.openai.chat.completions.create({
+    model,
+    messages,
+    ...client.posthogOpts,
+  });
+
+  const rawContent = completion.choices[0]?.message?.content;
+  if (rawContent == null || (typeof rawContent === "string" && rawContent.trim() === "")) {
+    throw new Error(emptyContentError ?? `Pipeline step "${stepLabel}" returned no content`);
+  }
+
+  try {
+    return { raw: rawContent, parsed: extractJson(rawContent) };
+  } catch (err) {
+    if (!wrapJsonErrors) throw err;
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Step ${stepLabel} returned invalid JSON: ${msg}`);
+  }
+}
+
+export interface RunNarrativeJsonPromptOptions extends CreateNarrativeClientOptions {
+  model: string;
+  promptContent: string;
+  inputJson: string;
+  systemPrompt?: string;
+  stepLabel?: string;
+  emptyContentError?: string;
+  wrapJsonErrors?: boolean;
+}
+
+/** Single-shot prompt helper: creates client, runs one completion, shuts down. */
+export async function runNarrativeJsonPrompt(options: RunNarrativeJsonPromptOptions): Promise<string> {
+  const client = createNarrativeClient(options);
+  try {
+    const { raw } = await runNarrativeCompletion({ ...options, client });
+    return raw;
+  } finally {
+    await client.shutdown();
+  }
+}

--- a/lib/run-periodic-pipeline.ts
+++ b/lib/run-periodic-pipeline.ts
@@ -6,42 +6,29 @@
  *   runWeeklyRollup(dailySummaries[])   → JSON string (weekly rollup)
  *   runMonthlyRollup(weeklySummaries[]) → JSON string (monthly rollup)
  *
- * Uses the same OpenRouter/OpenAI setup as run-pipeline.ts.
- * Requires OPENROUTER_API_KEY (falls back to OPENAI_API_KEY).
+ * Adapters over narrative-model-runner. Requires OPENROUTER_API_KEY
+ * (falls back to OPENAI_API_KEY).
  */
 
-import { readFileSync } from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
-import OpenAI from "openai";
 import type { Evidence } from "../types/evidence.js";
-import { extractJson, getDefaultModels } from "./run-pipeline.js";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const PROMPTS_DIR = join(__dirname, "..", "prompts");
-
-function loadPrompt(name: string): string {
-  return readFileSync(join(PROMPTS_DIR, name), "utf8").trim();
-}
-
-const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
-
-function makeClient(apiKey: string, baseURL?: string): OpenAI {
-  const opts: ConstructorParameters<typeof OpenAI>[0] = { apiKey };
-  if (baseURL) {
-    opts.baseURL = baseURL;
-    opts.defaultHeaders = {
-      "HTTP-Referer": "https://annualreview.dev",
-      "X-Title": "AnnualReview.dev",
-    };
-  }
-  return new OpenAI(opts);
-}
+import {
+  extractJson,
+  loadPrompt,
+  OPENROUTER_BASE,
+  resolveModel,
+  runNarrativeJsonPrompt,
+} from "./narrative-model-runner.js";
 
 export interface PeriodicPipelineOptions {
   apiKey?: string;
   model?: string;
   baseURL?: string;
+}
+
+function resolvePeriodicApiKey(apiKey?: string): string {
+  const resolved = apiKey ?? process.env.OPENROUTER_API_KEY ?? process.env.OPENAI_API_KEY;
+  if (!resolved) throw new Error("OPENROUTER_API_KEY required for periodic pipeline");
+  return resolved;
 }
 
 /**
@@ -51,18 +38,16 @@ export interface PeriodicPipelineOptions {
 export async function runDailySummary(
   evidence: Evidence,
   {
-    apiKey = process.env.OPENROUTER_API_KEY ?? process.env.OPENAI_API_KEY,
+    apiKey,
     model,
     baseURL = OPENROUTER_BASE,
   }: PeriodicPipelineOptions = {}
 ): Promise<string> {
-  if (!apiKey) throw new Error("OPENROUTER_API_KEY required for periodic pipeline");
-  const resolvedModel = model ?? getDefaultModels().free;
-  const openai = makeClient(apiKey, baseURL);
-  const prompt = loadPrompt("50_daily_summary.md");
+  const resolvedApiKey = resolvePeriodicApiKey(apiKey);
+  const resolvedModel = resolveModel({ model, premium: false });
+  const promptContent = loadPrompt("50_daily_summary.md");
 
-  // Slim the evidence down — daily runs are small by definition
-  const input = JSON.stringify({
+  const inputJson = JSON.stringify({
     timeframe: evidence.timeframe,
     contributions: evidence.contributions.map((c) => ({
       id: c.id,
@@ -76,17 +61,15 @@ export async function runDailySummary(
     })),
   });
 
-  const completion = await openai.chat.completions.create({
+  return runNarrativeJsonPrompt({
+    apiKey: resolvedApiKey,
+    baseURL,
     model: resolvedModel,
-    messages: [
-      { role: "user", content: `${prompt}\n\nINPUT JSON:\n${input}` },
-    ],
+    promptContent,
+    inputJson,
+    emptyContentError: "Daily summary pipeline returned no content",
+    wrapJsonErrors: false,
   });
-
-  const raw = completion.choices[0]?.message?.content;
-  if (!raw?.trim()) throw new Error("Daily summary pipeline returned no content");
-  extractJson(raw); // validate JSON
-  return raw;
 }
 
 /**
@@ -98,37 +81,34 @@ export async function runWeeklyRollup(
   weekEndDate: string,
   dailySummaryJsons: string[],
   {
-    apiKey = process.env.OPENROUTER_API_KEY ?? process.env.OPENAI_API_KEY,
+    apiKey,
     model,
     baseURL = OPENROUTER_BASE,
   }: PeriodicPipelineOptions = {}
 ): Promise<string> {
-  if (!apiKey) throw new Error("OPENROUTER_API_KEY required for periodic pipeline");
-  const resolvedModel = model ?? getDefaultModels().free;
-  const openai = makeClient(apiKey, baseURL);
-  const prompt = loadPrompt("51_weekly_rollup.md");
+  const resolvedApiKey = resolvePeriodicApiKey(apiKey);
+  const resolvedModel = resolveModel({ model, premium: false });
+  const promptContent = loadPrompt("51_weekly_rollup.md");
 
   const parsedDailies = dailySummaryJsons.map((s) => {
     try { return extractJson(s); } catch { return { headline: "No data", bullets: [] }; }
   });
 
-  const input = JSON.stringify({
+  const inputJson = JSON.stringify({
     week_start: weekStart,
     week_end: weekEndDate,
     daily_summaries: parsedDailies,
   });
 
-  const completion = await openai.chat.completions.create({
+  return runNarrativeJsonPrompt({
+    apiKey: resolvedApiKey,
+    baseURL,
     model: resolvedModel,
-    messages: [
-      { role: "user", content: `${prompt}\n\nINPUT JSON:\n${input}` },
-    ],
+    promptContent,
+    inputJson,
+    emptyContentError: "Weekly rollup pipeline returned no content",
+    wrapJsonErrors: false,
   });
-
-  const raw = completion.choices[0]?.message?.content;
-  if (!raw?.trim()) throw new Error("Weekly rollup pipeline returned no content");
-  extractJson(raw); // validate JSON
-  return raw;
 }
 
 /**
@@ -139,34 +119,31 @@ export async function runMonthlyRollup(
   month: string,
   weeklySummaryJsons: string[],
   {
-    apiKey = process.env.OPENROUTER_API_KEY ?? process.env.OPENAI_API_KEY,
+    apiKey,
     model,
     baseURL = OPENROUTER_BASE,
   }: PeriodicPipelineOptions = {}
 ): Promise<string> {
-  if (!apiKey) throw new Error("OPENROUTER_API_KEY required for periodic pipeline");
-  const resolvedModel = model ?? getDefaultModels().free;
-  const openai = makeClient(apiKey, baseURL);
-  const prompt = loadPrompt("52_monthly_rollup.md");
+  const resolvedApiKey = resolvePeriodicApiKey(apiKey);
+  const resolvedModel = resolveModel({ model, premium: false });
+  const promptContent = loadPrompt("52_monthly_rollup.md");
 
   const parsedWeeklies = weeklySummaryJsons.map((s) => {
     try { return extractJson(s); } catch { return { headline: "No data", themes: [] }; }
   });
 
-  const input = JSON.stringify({
+  const inputJson = JSON.stringify({
     month,
     weekly_summaries: parsedWeeklies,
   });
 
-  const completion = await openai.chat.completions.create({
+  return runNarrativeJsonPrompt({
+    apiKey: resolvedApiKey,
+    baseURL,
     model: resolvedModel,
-    messages: [
-      { role: "user", content: `${prompt}\n\nINPUT JSON:\n${input}` },
-    ],
+    promptContent,
+    inputJson,
+    emptyContentError: "Monthly rollup pipeline returned no content",
+    wrapJsonErrors: false,
   });
-
-  const raw = completion.choices[0]?.message?.content;
-  if (!raw?.trim()) throw new Error("Monthly rollup pipeline returned no content");
-  extractJson(raw); // validate JSON
-  return raw;
 }

--- a/lib/run-pipeline.ts
+++ b/lib/run-pipeline.ts
@@ -4,22 +4,16 @@
  */
 
 import { createHash } from "crypto";
-import { readFileSync } from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
-import OpenAI from "openai";
-import { OpenAI as PostHogOpenAI } from "@posthog/ai/openai";
-import { PostHog } from "posthog-node";
 import { fitEvidenceToBudget, estimateTokens, slimContributions } from "./context-budget.js";
+import {
+  createNarrativeClient,
+  loadPrompt,
+  OPENROUTER_BASE,
+  resolveModel,
+  runNarrativeCompletion,
+} from "./narrative-model-runner.js";
 import type { Evidence } from "../types/evidence.js";
 import type { ThemesOutput, BulletsOutput, StoriesOutput, SelfEvalOutput } from "./generate-markdown.js";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const PROMPTS_DIR = join(__dirname, "..", "prompts");
-
-function loadPrompt(name: string): string {
-  return readFileSync(join(PROMPTS_DIR, name), "utf8").trim();
-}
 
 const SYSTEM_PROMPT = loadPrompt("00_system.md");
 
@@ -60,65 +54,6 @@ const defaultCache = new PipelineCache();
 /** Clear the default result cache. Prefer injecting a fresh PipelineCache in tests. */
 export function clearPipelineCache(): void {
   defaultCache.clear();
-}
-
-// ── PostHog client factory ─────────────────────────────────────────────────────
-
-interface PostHogClientResult {
-  openai: OpenAI;
-  posthogOpts: Record<string, string | boolean>;
-  shutdown: () => Promise<void>;
-}
-
-function createOpenAiClient(
-  apiKey: string,
-  baseURL: string | undefined,
-  posthogTraceId: string | undefined,
-  posthogDistinctId: string | undefined
-): PostHogClientResult {
-  const posthogApiKey = process.env.POSTHOG_API_KEY;
-  const posthogClient = posthogApiKey
-    ? new PostHog(posthogApiKey, { host: process.env.POSTHOG_HOST || "https://us.i.posthog.com" })
-    : null;
-
-  const clientOpts: ConstructorParameters<typeof OpenAI>[0] = { apiKey };
-  if (baseURL) {
-    clientOpts.baseURL = baseURL;
-    clientOpts.defaultHeaders = {
-      "HTTP-Referer": "https://annualreview.dev",
-      "X-Title": "AnnualReview.dev",
-    };
-  }
-
-  const openai: OpenAI = posthogClient
-    ? new PostHogOpenAI({
-        ...clientOpts,
-        apiKey,
-        posthog: posthogClient,
-      } as ConstructorParameters<typeof PostHogOpenAI>[0]) as unknown as OpenAI
-    : new OpenAI(clientOpts);
-
-  const posthogOpts: Record<string, string | boolean> = {};
-  if (posthogTraceId != null) posthogOpts.posthogTraceId = posthogTraceId;
-  if (posthogDistinctId != null) posthogOpts.posthogDistinctId = posthogDistinctId;
-  if (posthogClient) posthogOpts.posthogCaptureImmediate = true;
-  if (posthogClient && baseURL?.includes("openrouter.ai")) posthogOpts.posthogProviderOverride = "openrouter";
-
-  return {
-    openai,
-    posthogOpts,
-    shutdown: () => (posthogClient ? posthogClient.shutdown() : Promise.resolve()),
-  };
-}
-
-// ── extractJson ────────────────────────────────────────────────────────────────
-
-/** Pull first {...} from LLM response text and parse as JSON. */
-export function extractJson(text: string): unknown {
-  const start = text.indexOf("{");
-  const end = text.lastIndexOf("}") + 1;
-  if (start === -1 || end === 0) throw new Error("No JSON object in response");
-  return JSON.parse(text.slice(start, end));
 }
 
 // ── Pipeline step definitions ──────────────────────────────────────────────────
@@ -279,14 +214,6 @@ export interface PipelineOptions {
   cache?: PipelineCache;
 }
 
-/** Default model ids for free and premium (OpenRouter). */
-export function getDefaultModels(): { free: string; premium: string } {
-  return {
-    free: process.env.LLM_MODEL ?? "anthropic/claude-3-haiku",
-    premium: process.env.PREMIUM_LLM_MODEL ?? "anthropic/claude-haiku-4.5",
-  };
-}
-
 /** Max user-message tokens by tier. Env override: MAX_USER_TOKENS_FREE, MAX_USER_TOKENS_PREMIUM. */
 export function getMaxUserTokensForTier(premium: boolean): number {
   const envKey = premium ? "MAX_USER_TOKENS_PREMIUM" : "MAX_USER_TOKENS_FREE";
@@ -297,8 +224,6 @@ export function getMaxUserTokensForTier(premium: boolean): number {
   }
   return premium ? 184_000 : 500_000;
 }
-
-const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
 
 // ── Prompt loop ────────────────────────────────────────────────────────────────
 
@@ -317,7 +242,7 @@ export async function runPipeline(
 ): Promise<PipelineResult> {
   if (!apiKey) throw new Error("OPENROUTER_API_KEY required");
 
-  const resolvedModel = model ?? getDefaultModels()[premium ? "premium" : "free"];
+  const resolvedModel = resolveModel({ model, premium });
 
   const cached = cache.get(evidence, resolvedModel);
   if (cached) {
@@ -334,12 +259,12 @@ export async function runPipeline(
     return cached;
   }
 
-  const { openai, posthogOpts, shutdown } = createOpenAiClient(
+  const client = createNarrativeClient({
     apiKey,
     baseURL,
     posthogTraceId,
-    posthogDistinctId
-  );
+    posthogDistinctId,
+  });
 
   const total = STEPS.length;
 
@@ -376,25 +301,14 @@ export async function runPipeline(
       const stepStart = Date.now();
       const input = step.buildInput(evidence, previousResults);
       const promptContent = loadPrompt(step.promptFile);
-      const completion = await openai.chat.completions.create({
+      const { parsed: stepResult } = await runNarrativeCompletion({
+        client,
         model: resolvedModel,
-        messages: [
-          { role: "system", content: SYSTEM_PROMPT },
-          { role: "user", content: `${promptContent}\n\nINPUT JSON:\n${input}` },
-        ],
-        ...posthogOpts,
+        promptContent,
+        inputJson: input,
+        systemPrompt: SYSTEM_PROMPT,
+        stepLabel: step.key,
       });
-      const rawContent = completion.choices[0]?.message?.content;
-      if (rawContent == null || (typeof rawContent === "string" && rawContent.trim() === "")) {
-        throw new Error(`Pipeline step "${step.key}" returned no content`);
-      }
-      let stepResult: unknown;
-      try {
-        stepResult = extractJson(rawContent);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`Step ${step.key} returned invalid JSON: ${msg}`);
-      }
       (previousResults as Record<string, unknown>)[step.key] = stepResult;
       prevStepMs = Date.now() - stepStart;
       prevStepPayloadTokens = estimateTokens(input);
@@ -411,6 +325,8 @@ export async function runPipeline(
     cache.set(evidence, resolvedModel, result);
     return result;
   } finally {
-    await shutdown();
+    await client.shutdown();
   }
 }
+
+export { getDefaultModels, extractJson } from "./narrative-model-runner.js";

--- a/server/routes/payments.ts
+++ b/server/routes/payments.ts
@@ -12,7 +12,7 @@ import type { IncomingMessage, ServerResponse } from "http";
 import type { SessionData } from "../../lib/session-store.js";
 import Stripe from "stripe";
 import { awardCredits, getCredits, getCreditsPerPurchase } from "../../lib/payment-store.js";
-import { getDefaultModels } from "../../lib/run-pipeline.js";
+import { getDefaultModels } from "../../lib/narrative-model-runner.js";
 import { STRIPE_API_VERSION } from "../config.js";
 import { respondJson } from "../helpers.js";
 

--- a/test/narrative-model-runner.test.js
+++ b/test/narrative-model-runner.test.js
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  extractJson,
+  getDefaultModels,
+  resolveModel,
+  createNarrativeClient,
+  runNarrativeCompletion,
+  runNarrativeJsonPrompt,
+  OPENROUTER_BASE,
+} from "../lib/narrative-model-runner.js";
+
+let createCallCount = 0;
+let lastCreateArgs = null;
+function MockOpenAI() {
+  this.chat = {
+    completions: {
+      create: (args) => {
+        createCallCount++;
+        lastCreateArgs = args;
+        return Promise.resolve({
+          choices: [{ message: { content: '{"ok":true}' } }],
+        });
+      },
+    },
+  };
+}
+vi.mock("@posthog/ai/openai", () => ({ OpenAI: MockOpenAI }));
+vi.mock("posthog-node", () => ({
+  PostHog: function MockPostHog() {
+    this.shutdown = () => Promise.resolve();
+  },
+}));
+
+describe("extractJson", () => {
+  it("extracts a single JSON object", () => {
+    expect(extractJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("strips leading and trailing text", () => {
+    expect(extractJson("Here is the result:\n{\"themes\":[]}\nDone.")).toEqual({ themes: [] });
+  });
+
+  it("uses first { and last } for nested object", () => {
+    expect(extractJson("x{\"nested\":{\"b\":2}}y")).toEqual({ nested: { b: 2 } });
+  });
+
+  it("throws when no object found", () => {
+    expect(() => extractJson("no json here")).toThrow("No JSON object");
+  });
+});
+
+describe("getDefaultModels", () => {
+  it("returns env overrides when set", () => {
+    const prevFree = process.env.LLM_MODEL;
+    const prevPremium = process.env.PREMIUM_LLM_MODEL;
+    try {
+      process.env.LLM_MODEL = "free-model";
+      process.env.PREMIUM_LLM_MODEL = "premium-model";
+      expect(getDefaultModels()).toEqual({ free: "free-model", premium: "premium-model" });
+    } finally {
+      if (prevFree === undefined) delete process.env.LLM_MODEL;
+      else process.env.LLM_MODEL = prevFree;
+      if (prevPremium === undefined) delete process.env.PREMIUM_LLM_MODEL;
+      else process.env.PREMIUM_LLM_MODEL = prevPremium;
+    }
+  });
+});
+
+describe("resolveModel", () => {
+  it("uses explicit model when provided", () => {
+    expect(resolveModel({ model: "custom/model" })).toBe("custom/model");
+  });
+
+  it("selects premium default when premium is true", () => {
+    const { premium } = getDefaultModels();
+    expect(resolveModel({ premium: true })).toBe(premium);
+  });
+});
+
+describe("createNarrativeClient", () => {
+  beforeEach(() => {
+    createCallCount = 0;
+    lastCreateArgs = null;
+    process.env.POSTHOG_API_KEY = "ph_test";
+  });
+
+  it("sets posthogProviderOverride for OpenRouter base URL", async () => {
+    const client = createNarrativeClient({
+      apiKey: "sk-or-test",
+      baseURL: OPENROUTER_BASE,
+      posthogTraceId: "trace123",
+      posthogDistinctId: "user456",
+    });
+    try {
+      await client.openai.chat.completions.create({
+        model: "anthropic/claude-3-haiku",
+        messages: [{ role: "user", content: "hi" }],
+        ...client.posthogOpts,
+      });
+      expect(lastCreateArgs).toMatchObject({
+        posthogProviderOverride: "openrouter",
+        posthogTraceId: "trace123",
+        posthogDistinctId: "user456",
+      });
+    } finally {
+      await client.shutdown();
+    }
+  });
+});
+
+describe("runNarrativeCompletion", () => {
+  beforeEach(() => {
+    createCallCount = 0;
+    lastCreateArgs = null;
+    process.env.POSTHOG_API_KEY = "ph_test";
+  });
+
+  it("includes system prompt and parses JSON", async () => {
+    const client = createNarrativeClient({ apiKey: "sk-test", baseURL: OPENROUTER_BASE });
+    try {
+      const result = await runNarrativeCompletion({
+        client,
+        model: "anthropic/claude-3-haiku",
+        promptContent: "Do the thing",
+        inputJson: '{"x":1}',
+        systemPrompt: "You are helpful",
+        stepLabel: "themes",
+      });
+      expect(result.parsed).toEqual({ ok: true });
+      expect(lastCreateArgs.messages[0]).toEqual({ role: "system", content: "You are helpful" });
+      expect(lastCreateArgs.messages[1].content).toContain("Do the thing");
+      expect(lastCreateArgs.messages[1].content).toContain('INPUT JSON:\n{"x":1}');
+    } finally {
+      await client.shutdown();
+    }
+  });
+
+  it("wraps invalid JSON with step label by default", async () => {
+    const client = createNarrativeClient({ apiKey: "sk-test", baseURL: OPENROUTER_BASE });
+    client.openai.chat.completions.create = () =>
+      Promise.resolve({ choices: [{ message: { content: "not json" } }] });
+    try {
+      await expect(
+        runNarrativeCompletion({
+          client,
+          model: "anthropic/claude-3-haiku",
+          promptContent: "Do the thing",
+          inputJson: "{}",
+          stepLabel: "themes",
+        })
+      ).rejects.toThrow(/Step themes returned invalid JSON/);
+    } finally {
+      await client.shutdown();
+    }
+  });
+
+  it("uses custom empty content error", async () => {
+    const client = createNarrativeClient({ apiKey: "sk-test", baseURL: OPENROUTER_BASE });
+    client.openai.chat.completions.create = () =>
+      Promise.resolve({ choices: [{ message: { content: "" } }] });
+    try {
+      await expect(
+        runNarrativeCompletion({
+          client,
+          model: "anthropic/claude-3-haiku",
+          promptContent: "Do the thing",
+          inputJson: "{}",
+          emptyContentError: "Daily summary pipeline returned no content",
+        })
+      ).rejects.toThrow("Daily summary pipeline returned no content");
+    } finally {
+      await client.shutdown();
+    }
+  });
+});
+
+describe("runNarrativeJsonPrompt", () => {
+  beforeEach(() => {
+    createCallCount = 0;
+    lastCreateArgs = null;
+    process.env.POSTHOG_API_KEY = "ph_test";
+  });
+
+  it("returns raw JSON string from a single-shot prompt", async () => {
+    const raw = await runNarrativeJsonPrompt({
+      apiKey: "sk-test",
+      baseURL: OPENROUTER_BASE,
+      model: "anthropic/claude-3-haiku",
+      promptContent: "Summarize",
+      inputJson: '{"day":"2025-01-01"}',
+    });
+    expect(raw).toBe('{"ok":true}');
+    expect(createCallCount).toBe(1);
+  });
+});

--- a/test/run-pipeline.test.js
+++ b/test/run-pipeline.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { extractJson, runPipeline, clearPipelineCache, getMaxUserTokensForTier, PipelineCache } from "../lib/run-pipeline.js";
+import { runPipeline, clearPipelineCache, getMaxUserTokensForTier, PipelineCache } from "../lib/run-pipeline.js";
 
 const mockThemes = { themes: [{ theme_id: "t1", theme_name: "Reliability" }] };
 const mockBullets = { bullets_by_theme: [], top_10_bullets_overall: [] };
@@ -94,24 +94,6 @@ describe("getMaxUserTokensForTier", () => {
         process.env.MAX_USER_TOKENS_FREE = previousFree;
       }
     }
-  });
-});
-
-describe("extractJson", () => {
-  it("extracts a single JSON object", () => {
-    expect(extractJson('{"a":1}')).toEqual({ a: 1 });
-  });
-
-  it("strips leading and trailing text", () => {
-    expect(extractJson("Here is the result:\n{\"themes\":[]}\nDone.")).toEqual({ themes: [] });
-  });
-
-  it("uses first { and last } for nested object", () => {
-    expect(extractJson("x{\"nested\":{\"b\":2}}y")).toEqual({ nested: { b: 2 } });
-  });
-
-  it("throws when no object found", () => {
-    expect(() => extractJson("no json here")).toThrow("No JSON object");
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `lib/narrative-model-runner.ts` as the shared seam for OpenRouter client setup, model defaults, prompt execution, JSON extraction, and PostHog tracing.
- Refactor `run-pipeline` and `run-periodic-pipeline` into adapters over the runner instead of duplicating LLM setup/parsing logic.
- Add direct runner tests and move `extractJson` coverage out of `run-pipeline.test.js`.

Closes #141

## Test plan
- [x] `yarn vitest run test/narrative-model-runner.test.js test/run-pipeline.test.js test/routes-periodic.test.js test/payments.test.js`
- [x] `yarn typecheck`

Made with [Cursor](https://cursor.com)