### PR TITLE
Extract generate workspace module (GH 143)

### DIFF
--- a/src/Generate.tsx
+++ b/src/Generate.tsx
@@ -1,20 +1,16 @@
 // Page: 1) Get GitHub data (OAuth or token or CLI), 2) Paste/upload evidence JSON, 3) Generate → themes, bullets, stories, self-eval.
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import "./Generate.css";
 import { generateMarkdown } from "../lib/generate-markdown.js";
 import type { Timeframe } from "../types/evidence.js";
 import { posthog } from "./posthog";
-import { parseJsonResponse, pollJob } from "./api.js";
 import { useAuth } from "./hooks/useAuth";
 import { useGitHubCollect } from "./hooks/useGitHubCollect";
 import { useSnapshots } from "./hooks/useSnapshots";
+import { useGenerateWorkspace } from "./workspaces/generate";
 import CollectForm from "./CollectForm";
 import NarrativeView, { type NarrativeViewProps } from "./NarrativeView";
-import { PAYMENTS_NOT_CONFIGURED } from "../lib/api-error-codes.js";
-
-/** Milliseconds to wait for React state to settle before auto-generating after Stripe redirect. */
-const STRIPE_RETURN_DELAY_MS = 100;
 
 const GITHUB_TOKEN_URL =
   "https://github.com/settings/tokens/new?scopes=repo&description=AnnualReview.dev";
@@ -40,116 +36,15 @@ interface PipelineResultLike {
 
 export default function Generate() {
   const { user, authChecked, logout } = useAuth();
-  const [evidenceText, setEvidenceText] = useState("");
-  const [goals, setGoals] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [progress, setProgress] = useState("");
-  const [result, setResult] = useState<PipelineResultLike | null>(null);
-  const [isPremiumResult, setIsPremiumResult] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [paymentsEnabled, setPaymentsEnabled] = useState(false);
-  const [creditsPerPurchase, setCreditsPerPurchase] = useState(5);
-  const [priceCents, setPriceCents] = useState(100);
-  const [freeModel, setFreeModel] = useState<string>("");
-  const [premiumModel, setPremiumModel] = useState<string>("");
-  /** Credits remaining for the stored Stripe session ID, or null if unknown. */
-  const [premiumCredits, setPremiumCredits] = useState<number | null>(null);
-
-  /** Snapshot save state */
-  const [snapshotPeriod, setSnapshotPeriod] = useState<"daily" | "weekly" | "monthly" | "custom">("weekly");
-  const [snapshotLabel, setSnapshotLabel] = useState("");
-  const [snapshotSaving, setSnapshotSaving] = useState(false);
-  const [snapshotSaved, setSnapshotSaved] = useState(false);
-  const [snapshotError, setSnapshotError] = useState<string | null>(null);
-
   const { saveSnapshot } = useSnapshots({ user });
+  const ws = useGenerateWorkspace({ user, saveSnapshot });
 
-  const onEvidenceReceived = useCallback((text: string) => {
-    setEvidenceText(text);
-    setError(null);
-  }, []);
+  const onEvidenceReceived = useCallback(
+    (text: string) => ws.setEvidenceTextClearingError(text),
+    [ws]
+  );
 
   const [dataTab, setDataTab] = useState<"app" | "token" | "terminal">("app");
-  const [authError, setAuthError] = useState(false);
-
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    if (params.get("error") === "auth_failed") {
-      setAuthError(true);
-      window.history.replaceState({}, "", window.location.pathname);
-    }
-    // After returning from Stripe, persist session ID to localStorage for reuse across sessions.
-    const sessionId = params.get("session_id");
-    const isPremium = params.get("premium") === "1";
-    if (sessionId && isPremium) {
-      window.history.replaceState({}, "", window.location.pathname);
-      try { localStorage.setItem("premium_stripe_session_id", sessionId); } catch { /* ignore */ }
-      // Also store in sessionStorage so the post-redirect auto-generate effect picks it up.
-      try { sessionStorage.setItem("stripe_session_id", sessionId); } catch { /* ignore */ }
-    }
-  }, []);
-
-  // Load a snapshot or merged evidence from URL params / sessionStorage
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-
-    // Load merged evidence passed via sessionStorage from the Dashboard merge action
-    if (params.get("from_snapshot_merge") === "1") {
-      window.history.replaceState({}, "", window.location.pathname);
-      let merged: string | null = null;
-      try { merged = sessionStorage.getItem("merged_evidence"); } catch { /* ignore */ }
-      if (merged) {
-        try { sessionStorage.removeItem("merged_evidence"); } catch { /* ignore */ }
-        setEvidenceText(merged);
-        setError(null);
-      }
-      return;
-    }
-
-    // Load a single snapshot by id
-    const snapshotId = params.get("snapshot_id");
-    if (snapshotId) {
-      window.history.replaceState({}, "", window.location.pathname);
-      fetch(`/api/snapshots/${snapshotId}`, { credentials: "include" })
-        .then((res) => (res.ok ? res.json() : null))
-        .then((data: { evidence?: unknown } | null) => {
-          if (data?.evidence) {
-            setEvidenceText(JSON.stringify(data.evidence, null, 2));
-            setError(null);
-          }
-        })
-        .catch(() => {});
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    fetch("/api/payments/config")
-      .then((res) => (res.ok ? res.json() : { enabled: false }))
-      .then((data: {
-        enabled?: boolean;
-        credits_per_purchase?: number;
-        price_cents?: number;
-        free_model?: string;
-        premium_model?: string;
-      }) => {
-        setPaymentsEnabled(!!data.enabled);
-        if (data.credits_per_purchase != null) setCreditsPerPurchase(data.credits_per_purchase);
-        if (data.price_cents != null) setPriceCents(data.price_cents);
-        if (data.free_model) setFreeModel(data.free_model);
-        if (data.premium_model) setPremiumModel(data.premium_model);
-      })
-      .catch(() => setPaymentsEnabled(false));
-  }, []);
-
-  // Fetch remaining credits when payments are enabled and user is logged in (session cookie identifies user)
-  useEffect(() => {
-    if (!paymentsEnabled || !user) return;
-    fetch("/api/payments/credits", { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : { credits: 0 }))
-      .then((data: { credits?: number }) => setPremiumCredits(data.credits ?? 0))
-      .catch(() => setPremiumCredits(0));
-  }, [paymentsEnabled, user]);
 
   const {
     collectStart,
@@ -165,268 +60,24 @@ export default function Generate() {
     handleFetchGitHub,
   } = useGitHubCollect({ onEvidenceReceived });
 
-  useEffect(() => {
-    if (!user) return;
-    fetch("/api/jobs", { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : {}))
-      .then((data: { latest?: { status?: string; result?: unknown } }) => {
-        const job = data.latest;
-        if (job?.status === "done" && job.result) {
-          setEvidenceText(JSON.stringify(job.result, null, 2));
-          setError(null);
-        }
-      })
-      .catch(() => {});
-  }, [user]);
-
-  const handleGenerate = async (
-    stripeSessionId?: string,
-    evidenceOverride?: string,
-    goalsOverride?: string
-  ) => {
-    const textToUse = evidenceOverride ?? evidenceText;
-    const goalsToUse = goalsOverride ?? goals;
-    let evidence: Record<string, unknown>;
-    try {
-      evidence = JSON.parse(textToUse) as Record<string, unknown>;
-    } catch {
-      const looksTruncated =
-        /[\{\[,]\s*$/.test(textToUse.trim()) ||
-        !textToUse.includes('"contributions"');
-      setError(
-        looksTruncated
-          ? 'Invalid JSON—looks truncated (e.g. missing contributions or closing brackets). Try "Upload evidence.json" instead of pasting, or paste the full file again.'
-          : "Invalid JSON. Paste or upload a valid evidence.json."
-      );
-      return;
-    }
-    const tf = evidence.timeframe as { start_date?: string; end_date?: string } | undefined;
-    if (
-      !tf?.start_date ||
-      !tf?.end_date ||
-      !Array.isArray(evidence.contributions)
-    ) {
-      setError(
-        "Evidence must have timeframe.start_date, timeframe.end_date, and contributions array."
-      );
-      return;
-    }
-    if (
-      (goalsToUse as string).trim() &&
-      !(evidence as { goals?: string }).goals
-    ) {
-      evidence = { ...evidence, goals: (goalsToUse as string).trim() };
-    }
-    if (stripeSessionId) {
-      evidence = { ...evidence, _stripe_session_id: stripeSessionId };
-    }
-    const posthogDistinctId = posthog?.get_distinct_id?.();
-    if (posthogDistinctId) {
-      const posthogTraceId =
-        globalThis.crypto?.randomUUID?.() ??
-        `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-      evidence = {
-        ...evidence,
-        posthog_distinct_id: posthogDistinctId,
-        posthog_trace_id: posthogTraceId,
-      };
-    }
-    setError(null);
-    setLoading(true);
-    setResult(null);
-    setIsPremiumResult(false);
-    setProgress("");
-    posthog?.capture("review_generate_started", { premium: !!stripeSessionId });
-    try {
-      const res = await fetch("/api/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(evidence),
-      });
-      const data = (await parseJsonResponse(res)) as {
-        job_id?: string;
-        premium?: boolean;
-        error?: string;
-        [key: string]: unknown;
-      };
-      if (res.status === 202 && data.job_id) {
-        const out = await pollJob(data.job_id, setProgress);
-        setResult(out as PipelineResultLike);
-        setIsPremiumResult(!!data.premium);
-        // Update displayed credit count if the server returned updated remaining credits
-        if (typeof data.credits_remaining === "number") {
-          setPremiumCredits(data.credits_remaining);
-        }
-        posthog?.capture("review_generate_completed", { premium: !!data.premium });
-      } else if (!res.ok) {
-        if ((data as { code?: string }).code === PAYMENTS_NOT_CONFIGURED) {
-          throw new Error("Premium generation is not available in this environment. Please use the free tier.");
-        }
-        throw new Error((data.error as string) || "Generate failed");
-      } else {
-        setResult(data as PipelineResultLike);
-        posthog?.capture("review_generate_completed");
-      }
-    } catch (e) {
-      const err = e as Error;
-      posthog?.capture("review_generate_failed", { error: err.message });
-      setError(err.message || "Pipeline failed. Is OPENROUTER_API_KEY set?");
-    } finally {
-      setLoading(false);
-      setProgress("");
-    }
-  };
-
-  const handleUsePremiumCredit = () => {
-    let sessionId: string | null = null;
-    try { sessionId = localStorage.getItem("premium_stripe_session_id"); } catch { /* ignore */ }
-    if (!sessionId) return;
-    handleGenerate(sessionId);
-  };
-
-  const handleUpgradeToPremium = async () => {
-    // Check we have valid evidence before redirecting to payment
-    try {
-      const ev = JSON.parse(evidenceText) as Record<string, unknown>;
-      const tf = ev.timeframe as { start_date?: string; end_date?: string } | undefined;
-      if (!tf?.start_date || !tf?.end_date || !Array.isArray(ev.contributions)) {
-        setError("Please load your evidence data first, then upgrade.");
-        return;
-      }
-    } catch {
-      setError("Please load your evidence data first, then upgrade.");
-      return;
-    }
-    setError(null);
-    // Save evidence so it survives the Stripe redirect
-    try {
-      sessionStorage.setItem("premium_evidence", evidenceText);
-      if (goals.trim()) sessionStorage.setItem("premium_goals", goals);
-    } catch {
-      // sessionStorage not available (unlikely in browser, ignore)
-    }
-    try {
-      const res = await fetch("/api/payments/checkout", { method: "POST" });
-      const data = (await parseJsonResponse(res)) as { url?: string; error?: string };
-      if (!res.ok || !data.url) {
-        throw new Error(data.error || "Could not start checkout");
-      }
-      posthog?.capture("premium_checkout_started");
-      window.location.href = data.url;
-    } catch (e) {
-      setError((e as Error).message || "Payment service unavailable. Try again later.");
-    }
-  };
-
-  // After returning from Stripe, restore evidence and auto-generate premium report
-  useEffect(() => {
-    let savedSessionId: string | null = null;
-    try { savedSessionId = sessionStorage.getItem("stripe_session_id"); } catch { /* ignore */ }
-    if (!savedSessionId) return;
-    try { sessionStorage.removeItem("stripe_session_id"); } catch { /* ignore */ }
-    let savedEvidence: string | null = null;
-    let savedGoals: string | null = null;
-    try { savedEvidence = sessionStorage.getItem("premium_evidence"); } catch { /* ignore */ }
-    try { savedGoals = sessionStorage.getItem("premium_goals"); } catch { /* ignore */ }
-    if (savedEvidence) {
-      try { sessionStorage.removeItem("premium_evidence"); } catch { /* ignore */ }
-      setEvidenceText(savedEvidence);
-    }
-    if (savedGoals) {
-      try { sessionStorage.removeItem("premium_goals"); } catch { /* ignore */ }
-      setGoals(savedGoals);
-    }
-    if (savedEvidence) {
-      // Use saved evidence/goals directly; state updates are async and may not be visible yet
-      const timer = setTimeout(
-        () => handleGenerate(savedSessionId!, savedEvidence!, savedGoals ?? undefined),
-        STRIPE_RETURN_DELAY_MS
-      );
-      return () => clearTimeout(timer);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const r = new FileReader();
-    r.onload = () => {
-      setEvidenceText(r.result as string);
-      setError(null);
-    };
-    r.readAsText(file);
-  };
-
-  const loadSample = async () => {
-    try {
-      const base = (import.meta.env.BASE_URL || "/").replace(/\/?$/, "/");
-      const res = await fetch(`${base}sample-evidence.json`);
-      if (!res.ok) throw new Error(`Sample not found (${res.status})`);
-      const data = await parseJsonResponse(res);
-      setEvidenceText(JSON.stringify(data, null, 2));
-      setError(null);
-    } catch (e) {
-      setError((e as Error).message || "Could not load sample.");
-    }
-  };
-
   const handleLogout = () => {
     posthog?.capture("logout");
     logout();
   };
 
-  const handleDownloadReport = () => {
-    let timeframe: Timeframe | undefined;
-    try {
-      const ev = JSON.parse(evidenceText) as { timeframe?: Timeframe };
-      timeframe = ev.timeframe;
-    } catch {
-      // no timeframe available
-    }
-    const md = generateMarkdown(
-      result as Parameters<typeof generateMarkdown>[0],
-      { timeframe }
-    );
-    const blob = new Blob([md], { type: "text/markdown" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "annual-review-report.md";
-    a.click();
-    URL.revokeObjectURL(url);
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    ws.handleFile(e.target.files?.[0]);
   };
 
-  const handleSaveSnapshot = async () => {
-    setSnapshotError(null);
-    setSnapshotSaved(false);
-    let ev: Record<string, unknown>;
-    try {
-      ev = JSON.parse(evidenceText) as Record<string, unknown>;
-    } catch {
-      setSnapshotError("Invalid JSON — load or paste evidence first.");
-      return;
-    }
-    const tf = ev.timeframe as { start_date?: string; end_date?: string } | undefined;
-    if (!tf?.start_date || !tf?.end_date) {
-      setSnapshotError("Evidence must have timeframe.start_date and timeframe.end_date.");
-      return;
-    }
-    setSnapshotSaving(true);
-    const id = await saveSnapshot({
-      period: snapshotPeriod,
-      start_date: tf.start_date,
-      end_date: tf.end_date,
-      evidence: ev as object,
-      label: snapshotLabel.trim() || undefined,
-    });
-    setSnapshotSaving(false);
-    if (id) {
-      setSnapshotSaved(true);
-      setSnapshotLabel("");
-      posthog?.capture("snapshot_saved", { period: snapshotPeriod });
-    }
-  };
+  const {
+    payments: {
+      enabled: paymentsEnabled,
+      creditsPerPurchase,
+      priceCents,
+      freeModel,
+      premiumModel,
+    },
+  } = ws;
 
   return (
     <div className="generate">
@@ -462,7 +113,7 @@ export default function Generate() {
       <main className="generate-main">
         <h1 className="generate-title">Generate review</h1>
 
-        {authError && (
+        {ws.authError && (
           <div className="generate-error" role="alert">
             GitHub sign-in didn’t complete. For local dev, add this callback URL
             to your GitHub OAuth app:{" "}
@@ -685,14 +336,14 @@ yarn normalize --input raw.json --output evidence.json`}
             <input
               type="file"
               accept=".json,application/json"
-              onChange={handleFile}
+              onChange={handleFileInput}
               className="generate-file-input"
             />
           </label>
           <button
             type="button"
             className="generate-sample-btn"
-            onClick={loadSample}
+            onClick={() => void ws.loadSample()}
           >
             Try sample
           </button>
@@ -700,10 +351,10 @@ yarn normalize --input raw.json --output evidence.json`}
         <textarea
           className="generate-textarea"
           placeholder='{"timeframe": {"start_date": "2025-01-01", "end_date": "2025-12-31"}, "contributions": [...]}'
-          value={evidenceText}
+          value={ws.evidenceText}
           onChange={(e) => {
-            setEvidenceText(e.target.value);
-            setError(null);
+            ws.setEvidenceText(e.target.value);
+            ws.setError(null);
           }}
           rows={8}
           spellCheck={false}
@@ -727,8 +378,8 @@ yarn normalize --input raw.json --output evidence.json`}
             placeholder={
               "One goal per line, e.g.:\nImprove system reliability\nGrow as a technical leader\nShip the new onboarding flow"
             }
-            value={goals}
-            onChange={(e) => setGoals(e.target.value)}
+            value={ws.goals}
+            onChange={(e) => ws.setGoals(e.target.value)}
             rows={4}
             spellCheck={false}
           />
@@ -738,8 +389,7 @@ yarn normalize --input raw.json --output evidence.json`}
           </p>
         </div>
 
-        {/* Save as Snapshot — only shown for logged-in users once evidence is loaded */}
-        {authChecked && user && evidenceText.trim() && (
+        {authChecked && user && ws.evidenceText.trim() && (
           <div className="generate-snapshot-section">
             <h2 className="generate-step-title generate-snapshot-title">
               Save as snapshot{" "}
@@ -753,8 +403,8 @@ yarn normalize --input raw.json --output evidence.json`}
             <div className="generate-snapshot-row">
               <select
                 className="generate-collect-input generate-snapshot-period"
-                value={snapshotPeriod}
-                onChange={(e) => setSnapshotPeriod(e.target.value as typeof snapshotPeriod)}
+                value={ws.snapshotPeriod}
+                onChange={(e) => ws.setSnapshotPeriod(e.target.value as typeof ws.snapshotPeriod)}
                 aria-label="Snapshot period"
               >
                 <option value="daily">Daily</option>
@@ -766,21 +416,21 @@ yarn normalize --input raw.json --output evidence.json`}
                 type="text"
                 className="generate-collect-input generate-snapshot-label-input"
                 placeholder="Label (optional, e.g. Q1 2025)"
-                value={snapshotLabel}
-                onChange={(e) => setSnapshotLabel(e.target.value)}
+                value={ws.snapshotLabel}
+                onChange={(e) => ws.setSnapshotLabel(e.target.value)}
                 aria-label="Snapshot label"
               />
               <button
                 type="button"
                 className="generate-collect-btn generate-snapshot-btn"
-                onClick={handleSaveSnapshot}
-                disabled={snapshotSaving}
+                onClick={() => void ws.saveSnapshot()}
+                disabled={ws.snapshotSaving}
               >
-                {snapshotSaving ? "Saving…" : "Save snapshot"}
+                {ws.snapshotSaving ? "Saving…" : "Save snapshot"}
               </button>
             </div>
-            {snapshotError && <p className="generate-error">{snapshotError}</p>}
-            {snapshotSaved && (
+            {ws.snapshotError && <p className="generate-error">{ws.snapshotError}</p>}
+            {ws.snapshotSaved && (
               <p className="generate-snapshot-saved">
                 ✓ Snapshot saved.{" "}
                 <a href="/dashboard">View all snapshots →</a>
@@ -789,25 +439,25 @@ yarn normalize --input raw.json --output evidence.json`}
           </div>
         )}
 
-        {error && <p className="generate-error">{error}</p>}
+        {ws.error && <p className="generate-error">{ws.error}</p>}
 
-        <div className="generate-actions" aria-busy={loading}>
-          {loading ? (
+        <div className="generate-actions" aria-busy={ws.loading}>
+          {ws.loading ? (
             <div className="generate-actions-progress">
               <div
                 className="generate-progress-bar"
                 role="progressbar"
                 aria-label="Generating review"
-                aria-valuetext={progress || undefined}
+                aria-valuetext={ws.progress || undefined}
               />
-              {progress && <p className="generate-progress">{progress}</p>}
+              {ws.progress && <p className="generate-progress">{ws.progress}</p>}
             </div>
           ) : (
             <div className="generate-actions-buttons">
               <button
                 type="button"
                 className="generate-btn"
-                onClick={() => handleGenerate()}
+                onClick={() => void ws.generate()}
               >
                 <span className="generate-btn-inner">
                   <span>{paymentsEnabled ? "3. Generate review (free)" : "3. Generate review"}</span>
@@ -815,24 +465,24 @@ yarn normalize --input raw.json --output evidence.json`}
                 </span>
               </button>
               {paymentsEnabled && (
-                premiumCredits !== null && premiumCredits > 0 ? (
+                ws.premiumCredits !== null && ws.premiumCredits > 0 ? (
                   <button
                     type="button"
                     className="generate-btn generate-btn-premium"
-                    onClick={handleUsePremiumCredit}
+                    onClick={ws.usePremiumCredit}
                     title={`Uses ${premiumModel ? formatModelName(premiumModel) : "premium"} model`}
                   >
                     <span className="generate-btn-inner">
                       <span>✦ Generate premium report</span>
                       {premiumModel && <span className="generate-btn-model">{formatModelName(premiumModel)}</span>}
-                      <span className="generate-btn-credits">{premiumCredits} credit{premiumCredits !== 1 ? "s" : ""} left</span>
+                      <span className="generate-btn-credits">{ws.premiumCredits} credit{ws.premiumCredits !== 1 ? "s" : ""} left</span>
                     </span>
                   </button>
                 ) : (
                   <button
                     type="button"
                     className="generate-btn generate-btn-premium"
-                    onClick={handleUpgradeToPremium}
+                    onClick={() => void ws.upgradeToPremium()}
                     title={`${creditsPerPurchase} credits for $${(priceCents / 100).toFixed(2)} (1 run = 1 credit). Uses ${premiumModel ? formatModelName(premiumModel) : "premium"} model.`}
                   >
                     <span className="generate-btn-inner">
@@ -846,19 +496,19 @@ yarn normalize --input raw.json --output evidence.json`}
           )}
         </div>
 
-        {result && (
+        {ws.result && (
           <div className="generate-result">
             <h2>
               Your review
-              {isPremiumResult && (
+              {ws.isPremiumResult && (
                 <span className="generate-premium-badge">✦ Premium</span>
               )}
             </h2>
-            <NarrativeView {...(result as NarrativeViewProps)} />
+            <NarrativeView {...(ws.result as NarrativeViewProps)} />
             <ReportSection
-              result={result}
-              evidenceText={evidenceText}
-              onDownload={handleDownloadReport}
+              result={ws.result}
+              evidenceText={ws.evidenceText}
+              onDownload={ws.downloadReport}
             />
           </div>
         )}

--- a/src/workspaces/generate/commands.ts
+++ b/src/workspaces/generate/commands.ts
@@ -1,0 +1,249 @@
+import { PAYMENTS_NOT_CONFIGURED } from "../../../lib/api-error-codes.js";
+import { parseJsonResponse, type pollJob } from "../../api.js";
+import type {
+  GenerateCommandResult,
+  PaymentsConfig,
+  PipelineResult,
+  SaveSnapshotFn,
+  SaveSnapshotResult,
+  SimpleCommandResult,
+  StorageAdapter,
+} from "./types.js";
+import {
+  prepareEvidenceForGenerate,
+  validateEvidenceJson,
+  validateEvidenceTimeframe,
+} from "./validation.js";
+import type { SnapshotPeriod } from "../../hooks/useSnapshots.js";
+
+interface PosthogLike {
+  capture?: (event: string, props?: Record<string, unknown>) => void;
+  get_distinct_id?: () => string | undefined;
+}
+
+export async function fetchPaymentsConfig(fetchFn: typeof fetch): Promise<PaymentsConfig> {
+  try {
+    const res = await fetchFn("/api/payments/config");
+    const data = res.ok
+      ? ((await parseJsonResponse(res)) as {
+          enabled?: boolean;
+          credits_per_purchase?: number;
+          price_cents?: number;
+          free_model?: string;
+          premium_model?: string;
+        })
+      : { enabled: false };
+    return {
+      enabled: !!data.enabled,
+      creditsPerPurchase: data.credits_per_purchase ?? 5,
+      priceCents: data.price_cents ?? 100,
+      freeModel: data.free_model ?? "",
+      premiumModel: data.premium_model ?? "",
+    };
+  } catch {
+    return {
+      enabled: false,
+      creditsPerPurchase: 5,
+      priceCents: 100,
+      freeModel: "",
+      premiumModel: "",
+    };
+  }
+}
+
+export async function fetchPremiumCredits(fetchFn: typeof fetch): Promise<number> {
+  try {
+    const res = await fetchFn("/api/payments/credits", { credentials: "include" });
+    const data = res.ok
+      ? ((await parseJsonResponse(res)) as { credits?: number })
+      : { credits: 0 };
+    return data.credits ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+export async function fetchLatestJobEvidence(fetchFn: typeof fetch): Promise<string | null> {
+  try {
+    const res = await fetchFn("/api/jobs", { credentials: "include" });
+    const data = res.ok
+      ? ((await parseJsonResponse(res)) as { latest?: { status?: string; result?: unknown } })
+      : {};
+    const job = data.latest;
+    if (job?.status === "done" && job.result) {
+      return JSON.stringify(job.result, null, 2);
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export async function fetchSnapshotEvidence(
+  fetchFn: typeof fetch,
+  snapshotId: string
+): Promise<string | null> {
+  try {
+    const res = await fetchFn(`/api/snapshots/${snapshotId}`, { credentials: "include" });
+    const data = res.ok
+      ? ((await parseJsonResponse(res)) as { evidence?: unknown })
+      : null;
+    if (data?.evidence) {
+      return JSON.stringify(data.evidence, null, 2);
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export async function runGenerate(opts: {
+  fetch: typeof fetch;
+  parseJsonResponse: typeof parseJsonResponse;
+  pollJob: typeof pollJob;
+  evidenceText: string;
+  goals: string;
+  stripeSessionId?: string;
+  onProgress?: (progress: string) => void;
+  posthog?: PosthogLike;
+  randomUUID?: () => string;
+}): Promise<GenerateCommandResult> {
+  const validation = validateEvidenceJson(opts.evidenceText);
+  if (!validation.ok) return { ok: false, error: validation.error };
+
+  const posthogDistinctId = opts.posthog?.get_distinct_id?.();
+  const posthogTraceId =
+    posthogDistinctId &&
+    (opts.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`);
+
+  const payload = prepareEvidenceForGenerate(validation.evidence, {
+    goals: opts.goals,
+    stripeSessionId: opts.stripeSessionId,
+    posthogDistinctId: posthogDistinctId || undefined,
+    posthogTraceId: posthogTraceId || undefined,
+  });
+
+  opts.posthog?.capture?.("review_generate_started", { premium: !!opts.stripeSessionId });
+
+  try {
+    const res = await opts.fetch("/api/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const data = (await opts.parseJsonResponse(res)) as {
+      job_id?: string;
+      premium?: boolean;
+      error?: string;
+      credits_remaining?: number;
+      [key: string]: unknown;
+    };
+
+    if (res.status === 202 && data.job_id) {
+      const out = (await opts.pollJob(data.job_id, opts.onProgress)) as PipelineResult;
+      opts.posthog?.capture?.("review_generate_completed", { premium: !!data.premium });
+      return {
+        ok: true,
+        result: out,
+        isPremium: !!data.premium,
+        creditsRemaining:
+          typeof data.credits_remaining === "number" ? data.credits_remaining : undefined,
+      };
+    }
+
+    if (!res.ok) {
+      if ((data as { code?: string }).code === PAYMENTS_NOT_CONFIGURED) {
+        return {
+          ok: false,
+          error:
+            "Premium generation is not available in this environment. Please use the free tier.",
+        };
+      }
+      return { ok: false, error: (data.error as string) || "Generate failed" };
+    }
+
+    opts.posthog?.capture?.("review_generate_completed");
+    return { ok: true, result: data as PipelineResult, isPremium: false };
+  } catch (e) {
+    const err = e as Error;
+    opts.posthog?.capture?.("review_generate_failed", { error: err.message });
+    return {
+      ok: false,
+      error: err.message || "Pipeline failed. Is OPENROUTER_API_KEY set?",
+    };
+  }
+}
+
+export async function runPremiumCheckout(opts: {
+  fetch: typeof fetch;
+  parseJsonResponse: typeof parseJsonResponse;
+  evidenceText: string;
+  goals: string;
+  session: StorageAdapter;
+  redirect?: (url: string) => void;
+  posthog?: PosthogLike;
+}): Promise<SimpleCommandResult> {
+  const validation = validateEvidenceJson(opts.evidenceText);
+  if (!validation.ok) {
+    return { ok: false, error: "Please load your evidence data first, then upgrade." };
+  }
+
+  try {
+    opts.session.setItem("premium_evidence", opts.evidenceText);
+    if (opts.goals.trim()) opts.session.setItem("premium_goals", opts.goals);
+  } catch {
+    /* sessionStorage not available */
+  }
+
+  try {
+    const res = await opts.fetch("/api/payments/checkout", { method: "POST" });
+    const data = (await opts.parseJsonResponse(res)) as { url?: string; error?: string };
+    if (!res.ok || !data.url) {
+      return { ok: false, error: data.error || "Could not start checkout" };
+    }
+    opts.posthog?.capture?.("premium_checkout_started");
+    const redirect = opts.redirect ?? ((url: string) => {
+      window.location.href = url;
+    });
+    redirect(data.url);
+    return { ok: true };
+  } catch (e) {
+    return {
+      ok: false,
+      error: (e as Error).message || "Payment service unavailable. Try again later.",
+    };
+  }
+}
+
+export async function runSaveSnapshot(opts: {
+  evidenceText: string;
+  snapshotPeriod: SnapshotPeriod;
+  snapshotLabel: string;
+  saveSnapshot: SaveSnapshotFn;
+}): Promise<SaveSnapshotResult> {
+  const validation = validateEvidenceTimeframe(opts.evidenceText);
+  if (!validation.ok) return { ok: false, error: validation.error };
+
+  const tf = validation.evidence.timeframe as { start_date: string; end_date: string };
+  const id = await opts.saveSnapshot({
+    period: opts.snapshotPeriod,
+    start_date: tf.start_date,
+    end_date: tf.end_date,
+    evidence: validation.evidence as object,
+    label: opts.snapshotLabel.trim() || undefined,
+  });
+
+  if (!id) {
+    return { ok: false, error: "Failed to save snapshot" };
+  }
+
+  return { ok: true, id };
+}
+
+export function getPremiumStripeSessionId(local: StorageAdapter): string | null {
+  try {
+    return local.getItem("premium_stripe_session_id");
+  } catch {
+    return null;
+  }
+}

--- a/src/workspaces/generate/index.ts
+++ b/src/workspaces/generate/index.ts
@@ -1,0 +1,5 @@
+export * from "./types.js";
+export * from "./validation.js";
+export * from "./recovery.js";
+export * from "./commands.js";
+export { useGenerateWorkspace, STRIPE_RETURN_DELAY_MS } from "./useGenerateWorkspace.js";

--- a/src/workspaces/generate/recovery.ts
+++ b/src/workspaces/generate/recovery.ts
@@ -1,0 +1,143 @@
+import type { StorageAdapter, StripeAutoGenerateRecovery, UrlRecoveryResult } from "./types.js";
+
+interface ParseUrlRecoveryOptions {
+  search: string;
+  replaceState: (data: unknown, title: string, url: string) => void;
+  storage?: {
+    local: StorageAdapter;
+    session: StorageAdapter;
+  };
+}
+
+function clearQuery(
+  replaceState: ParseUrlRecoveryOptions["replaceState"],
+  pathname = typeof window !== "undefined" ? window.location.pathname : "/"
+) {
+  replaceState({}, "", pathname);
+}
+
+export function parseUrlRecovery({
+  search,
+  replaceState,
+  storage,
+}: ParseUrlRecoveryOptions): UrlRecoveryResult {
+  const params = new URLSearchParams(search);
+  const result: UrlRecoveryResult = {};
+
+  if (params.get("error") === "auth_failed") {
+    result.authError = true;
+    clearQuery(replaceState);
+    return result;
+  }
+
+  const sessionId = params.get("session_id");
+  const isPremium = params.get("premium") === "1";
+  if (sessionId && isPremium) {
+    clearQuery(replaceState);
+    if (storage) {
+      try {
+        storage.local.setItem("premium_stripe_session_id", sessionId);
+      } catch {
+        /* ignore */
+      }
+      try {
+        storage.session.setItem("stripe_session_id", sessionId);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  if (params.get("from_snapshot_merge") === "1") {
+    clearQuery(replaceState);
+    if (storage) {
+      let merged: string | null = null;
+      try {
+        merged = storage.session.getItem("merged_evidence");
+      } catch {
+        /* ignore */
+      }
+      if (merged) {
+        try {
+          storage.session.removeItem("merged_evidence");
+        } catch {
+          /* ignore */
+        }
+        result.evidenceText = merged;
+      }
+    }
+    return result;
+  }
+
+  const snapshotId = params.get("snapshot_id");
+  if (snapshotId) {
+    clearQuery(replaceState);
+    result.snapshotId = snapshotId;
+  }
+
+  return result;
+}
+
+export function recoverStripeReturnFromUrl(
+  options: ParseUrlRecoveryOptions
+): UrlRecoveryResult | null {
+  const params = new URLSearchParams(options.search);
+  if (!params.get("session_id") || params.get("premium") !== "1") return null;
+  return parseUrlRecovery(options);
+}
+
+export function recoverStripeAutoGenerate({
+  session,
+}: {
+  session: StorageAdapter;
+}): StripeAutoGenerateRecovery | null {
+  let sessionId: string | null = null;
+  try {
+    sessionId = session.getItem("stripe_session_id");
+  } catch {
+    /* ignore */
+  }
+  if (!sessionId) return null;
+
+  try {
+    session.removeItem("stripe_session_id");
+  } catch {
+    /* ignore */
+  }
+
+  let evidenceText: string | null = null;
+  let goals: string | null = null;
+  try {
+    evidenceText = session.getItem("premium_evidence");
+  } catch {
+    /* ignore */
+  }
+  try {
+    goals = session.getItem("premium_goals");
+  } catch {
+    /* ignore */
+  }
+
+  if (evidenceText) {
+    try {
+      session.removeItem("premium_evidence");
+    } catch {
+      /* ignore */
+    }
+  }
+  if (goals) {
+    try {
+      session.removeItem("premium_goals");
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (!evidenceText) return null;
+
+  return {
+    sessionId,
+    evidenceText,
+    goals: goals ?? undefined,
+  };
+}

--- a/src/workspaces/generate/types.ts
+++ b/src/workspaces/generate/types.ts
@@ -1,0 +1,59 @@
+import type { SnapshotPeriod } from "../../hooks/useSnapshots.js";
+
+export interface PipelineResult {
+  themes?: unknown;
+  bullets?: unknown;
+  stories?: unknown;
+  self_eval?: unknown;
+}
+
+export interface PaymentsConfig {
+  enabled: boolean;
+  creditsPerPurchase: number;
+  priceCents: number;
+  freeModel: string;
+  premiumModel: string;
+}
+
+export interface StorageAdapter {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export interface UrlRecoveryResult {
+  authError?: boolean;
+  evidenceText?: string;
+  snapshotId?: string;
+}
+
+export interface StripeAutoGenerateRecovery {
+  sessionId: string;
+  evidenceText: string;
+  goals?: string;
+}
+
+export type GenerateCommandResult =
+  | {
+      ok: true;
+      result: PipelineResult;
+      isPremium: boolean;
+      creditsRemaining?: number;
+    }
+  | { ok: false; error: string };
+
+export type SimpleCommandResult = { ok: true } | { ok: false; error: string };
+
+export type SaveSnapshotResult =
+  | { ok: true; id: string }
+  | { ok: false; error: string };
+
+export interface SaveSnapshotFn {
+  (opts: {
+    period: SnapshotPeriod;
+    start_date: string;
+    end_date: string;
+    evidence: object;
+    label?: string;
+  }): Promise<string | null>;
+}

--- a/src/workspaces/generate/useGenerateWorkspace.ts
+++ b/src/workspaces/generate/useGenerateWorkspace.ts
@@ -1,0 +1,278 @@
+import { useState, useEffect, useCallback } from "react";
+import { generateMarkdown } from "../../../lib/generate-markdown.js";
+import type { Timeframe } from "../../../types/evidence.js";
+import { parseJsonResponse, pollJob } from "../../api.js";
+import type { AuthUser } from "../../hooks/useAuth.js";
+import type { SnapshotPeriod } from "../../hooks/useSnapshots.js";
+import { posthog } from "../../posthog";
+import {
+  fetchLatestJobEvidence,
+  fetchPaymentsConfig,
+  fetchPremiumCredits,
+  fetchSnapshotEvidence,
+  getPremiumStripeSessionId,
+  runGenerate,
+  runPremiumCheckout,
+  runSaveSnapshot,
+} from "./commands.js";
+import { parseUrlRecovery, recoverStripeAutoGenerate } from "./recovery.js";
+import type { PaymentsConfig, PipelineResult } from "./types.js";
+
+/** Milliseconds to wait for React state to settle before auto-generating after Stripe redirect. */
+export const STRIPE_RETURN_DELAY_MS = 100;
+
+interface UseGenerateWorkspaceOptions {
+  user: AuthUser | null;
+  saveSnapshot: (opts: {
+    period: SnapshotPeriod;
+    start_date: string;
+    end_date: string;
+    evidence: object;
+    label?: string;
+  }) => Promise<string | null>;
+}
+
+function browserStorage() {
+  return {
+    local: localStorage,
+    session: sessionStorage,
+  };
+}
+
+export function useGenerateWorkspace({ user, saveSnapshot }: UseGenerateWorkspaceOptions) {
+  const [evidenceText, setEvidenceText] = useState("");
+  const [goals, setGoals] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState("");
+  const [result, setResult] = useState<PipelineResult | null>(null);
+  const [isPremiumResult, setIsPremiumResult] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [payments, setPayments] = useState<PaymentsConfig>({
+    enabled: false,
+    creditsPerPurchase: 5,
+    priceCents: 100,
+    freeModel: "",
+    premiumModel: "",
+  });
+  const [premiumCredits, setPremiumCredits] = useState<number | null>(null);
+  const [authError, setAuthError] = useState(false);
+
+  const [snapshotPeriod, setSnapshotPeriod] = useState<SnapshotPeriod>("weekly");
+  const [snapshotLabel, setSnapshotLabel] = useState("");
+  const [snapshotSaving, setSnapshotSaving] = useState(false);
+  const [snapshotSaved, setSnapshotSaved] = useState(false);
+  const [snapshotError, setSnapshotError] = useState<string | null>(null);
+
+  const generate = useCallback(
+    async (
+      stripeSessionId?: string,
+      evidenceOverride?: string,
+      goalsOverride?: string
+    ) => {
+      setError(null);
+      setLoading(true);
+      setResult(null);
+      setIsPremiumResult(false);
+      setProgress("");
+
+      const outcome = await runGenerate({
+        fetch,
+        parseJsonResponse,
+        pollJob,
+        evidenceText: evidenceOverride ?? evidenceText,
+        goals: goalsOverride ?? goals,
+        stripeSessionId,
+        onProgress: setProgress,
+        posthog: posthog ?? undefined,
+        randomUUID: globalThis.crypto?.randomUUID?.bind(globalThis.crypto),
+      });
+
+      if (outcome.ok) {
+        setResult(outcome.result);
+        setIsPremiumResult(outcome.isPremium);
+        if (typeof outcome.creditsRemaining === "number") {
+          setPremiumCredits(outcome.creditsRemaining);
+        }
+      } else {
+        setError(outcome.error);
+      }
+
+      setLoading(false);
+      setProgress("");
+    },
+    [evidenceText, goals]
+  );
+
+  const usePremiumCredit = useCallback(() => {
+    const sessionId = getPremiumStripeSessionId(localStorage);
+    if (!sessionId) return;
+    void generate(sessionId);
+  }, [generate]);
+
+  const upgradeToPremium = useCallback(async () => {
+    setError(null);
+    const outcome = await runPremiumCheckout({
+      fetch,
+      parseJsonResponse,
+      evidenceText,
+      goals,
+      session: sessionStorage,
+      posthog: posthog ?? undefined,
+    });
+    if (!outcome.ok) setError(outcome.error);
+  }, [evidenceText, goals]);
+
+  const saveSnapshotCommand = useCallback(async () => {
+    setSnapshotError(null);
+    setSnapshotSaved(false);
+    setSnapshotSaving(true);
+    const outcome = await runSaveSnapshot({
+      evidenceText,
+      snapshotPeriod,
+      snapshotLabel,
+      saveSnapshot,
+    });
+    setSnapshotSaving(false);
+    if (outcome.ok) {
+      setSnapshotSaved(true);
+      setSnapshotLabel("");
+      posthog?.capture("snapshot_saved", { period: snapshotPeriod });
+    } else {
+      setSnapshotError(outcome.error);
+    }
+  }, [evidenceText, snapshotPeriod, snapshotLabel, saveSnapshot]);
+
+  const downloadReport = useCallback(() => {
+    let timeframe: Timeframe | undefined;
+    try {
+      const ev = JSON.parse(evidenceText) as { timeframe?: Timeframe };
+      timeframe = ev.timeframe;
+    } catch {
+      /* no timeframe */
+    }
+    const md = generateMarkdown(
+      result as Parameters<typeof generateMarkdown>[0],
+      { timeframe }
+    );
+    const blob = new Blob([md], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "annual-review-report.md";
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [evidenceText, result]);
+
+  const loadSample = useCallback(async () => {
+    try {
+      const base = (import.meta.env.BASE_URL || "/").replace(/\/?$/, "/");
+      const res = await fetch(`${base}sample-evidence.json`);
+      if (!res.ok) throw new Error(`Sample not found (${res.status})`);
+      const data = await parseJsonResponse(res);
+      setEvidenceText(JSON.stringify(data, null, 2));
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message || "Could not load sample.");
+    }
+  }, []);
+
+  const handleFile = useCallback((file: File | undefined) => {
+    if (!file) return;
+    const r = new FileReader();
+    r.onload = () => {
+      setEvidenceText(r.result as string);
+      setError(null);
+    };
+    r.readAsText(file);
+  }, []);
+
+  const setEvidenceTextClearingError = useCallback((text: string) => {
+    setEvidenceText(text);
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    const recovery = parseUrlRecovery({
+      search: window.location.search,
+      replaceState: window.history.replaceState.bind(window.history),
+      storage: browserStorage(),
+    });
+    if (recovery.authError) setAuthError(true);
+    if (recovery.evidenceText) {
+      setEvidenceText(recovery.evidenceText);
+      setError(null);
+    }
+    if (recovery.snapshotId) {
+      void fetchSnapshotEvidence(fetch, recovery.snapshotId).then((text) => {
+        if (text) {
+          setEvidenceText(text);
+          setError(null);
+        }
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchPaymentsConfig(fetch).then(setPayments);
+  }, []);
+
+  useEffect(() => {
+    if (!payments.enabled || !user) return;
+    void fetchPremiumCredits(fetch).then(setPremiumCredits);
+  }, [payments.enabled, user]);
+
+  useEffect(() => {
+    if (!user) return;
+    void fetchLatestJobEvidence(fetch).then((text) => {
+      if (text) {
+        setEvidenceText(text);
+        setError(null);
+      }
+    });
+  }, [user]);
+
+  useEffect(() => {
+    const recovery = recoverStripeAutoGenerate({ session: sessionStorage });
+    if (!recovery) return;
+    setEvidenceText(recovery.evidenceText);
+    if (recovery.goals) setGoals(recovery.goals);
+    const timer = setTimeout(
+      () =>
+        void generate(recovery.sessionId, recovery.evidenceText, recovery.goals),
+      STRIPE_RETURN_DELAY_MS
+    );
+    return () => clearTimeout(timer);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    evidenceText,
+    setEvidenceText,
+    setEvidenceTextClearingError,
+    goals,
+    setGoals,
+    loading,
+    progress,
+    result,
+    isPremiumResult,
+    error,
+    setError,
+    payments,
+    premiumCredits,
+    authError,
+    snapshotPeriod,
+    setSnapshotPeriod,
+    snapshotLabel,
+    setSnapshotLabel,
+    snapshotSaving,
+    snapshotSaved,
+    snapshotError,
+    generate,
+    usePremiumCredit,
+    upgradeToPremium,
+    saveSnapshot: saveSnapshotCommand,
+    downloadReport,
+    loadSample,
+    handleFile,
+  };
+}

--- a/src/workspaces/generate/validation.ts
+++ b/src/workspaces/generate/validation.ts
@@ -1,0 +1,77 @@
+export type EvidenceValidationResult =
+  | { ok: true; evidence: Record<string, unknown> }
+  | { ok: false; error: string };
+
+export function validateEvidenceJson(text: string): EvidenceValidationResult {
+  let evidence: Record<string, unknown>;
+  try {
+    evidence = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    const looksTruncated =
+      /[\{\[,]\s*$/.test(text.trim()) || !text.includes('"contributions"');
+    return {
+      ok: false,
+      error: looksTruncated
+        ? 'Invalid JSON—looks truncated (e.g. missing contributions or closing brackets). Try "Upload evidence.json" instead of pasting, or paste the full file again.'
+        : "Invalid JSON. Paste or upload a valid evidence.json.",
+    };
+  }
+
+  const tf = evidence.timeframe as { start_date?: string; end_date?: string } | undefined;
+  if (!tf?.start_date || !tf?.end_date || !Array.isArray(evidence.contributions)) {
+    return {
+      ok: false,
+      error:
+        "Evidence must have timeframe.start_date, timeframe.end_date, and contributions array.",
+    };
+  }
+
+  return { ok: true, evidence };
+}
+
+export function validateEvidenceTimeframe(text: string): EvidenceValidationResult {
+  let evidence: Record<string, unknown>;
+  try {
+    evidence = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return { ok: false, error: "Invalid JSON — load or paste evidence first." };
+  }
+
+  const tf = evidence.timeframe as { start_date?: string; end_date?: string } | undefined;
+  if (!tf?.start_date || !tf?.end_date) {
+    return {
+      ok: false,
+      error: "Evidence must have timeframe.start_date and timeframe.end_date.",
+    };
+  }
+
+  return { ok: true, evidence };
+}
+
+export function prepareEvidenceForGenerate(
+  evidence: Record<string, unknown>,
+  opts: {
+    goals?: string;
+    stripeSessionId?: string;
+    posthogDistinctId?: string;
+    posthogTraceId?: string;
+  } = {}
+): Record<string, unknown> {
+  let out = { ...evidence };
+
+  if (opts.goals?.trim() && !(out as { goals?: string }).goals) {
+    out = { ...out, goals: opts.goals.trim() };
+  }
+  if (opts.stripeSessionId) {
+    out = { ...out, _stripe_session_id: opts.stripeSessionId };
+  }
+  if (opts.posthogDistinctId) {
+    out = {
+      ...out,
+      posthog_distinct_id: opts.posthogDistinctId,
+      posthog_trace_id: opts.posthogTraceId,
+    };
+  }
+
+  return out;
+}

--- a/test/generate-workspace.test.ts
+++ b/test/generate-workspace.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  validateEvidenceJson,
+  prepareEvidenceForGenerate,
+} from "../src/workspaces/generate/validation.js";
+import {
+  parseUrlRecovery,
+  recoverStripeReturnFromUrl,
+  recoverStripeAutoGenerate,
+} from "../src/workspaces/generate/recovery.js";
+import {
+  runGenerate,
+  runPremiumCheckout,
+  runSaveSnapshot,
+  fetchPaymentsConfig,
+  fetchPremiumCredits,
+  fetchLatestJobEvidence,
+  fetchSnapshotEvidence,
+} from "../src/workspaces/generate/commands.js";
+import { PAYMENTS_NOT_CONFIGURED } from "../lib/api-error-codes.js";
+
+const validEvidence = {
+  timeframe: { start_date: "2025-01-01", end_date: "2025-12-31" },
+  contributions: [{ id: 1 }],
+};
+
+describe("validateEvidenceJson", () => {
+  it("accepts valid evidence JSON", () => {
+    const text = JSON.stringify(validEvidence);
+    expect(validateEvidenceJson(text)).toEqual({ ok: true, evidence: validEvidence });
+  });
+
+  it("rejects invalid JSON", () => {
+    const result = validateEvidenceJson("{not json");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/invalid json/i);
+  });
+
+  it("detects truncated JSON missing contributions", () => {
+    const result = validateEvidenceJson('{"timeframe": {');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/truncated/i);
+  });
+
+  it("requires timeframe and contributions", () => {
+    const result = validateEvidenceJson(JSON.stringify({ timeframe: {} }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/timeframe/i);
+  });
+});
+
+describe("prepareEvidenceForGenerate", () => {
+  it("merges goals when provided", () => {
+    const out = prepareEvidenceForGenerate(validEvidence, {
+      goals: "Ship faster",
+    });
+    expect(out.goals).toBe("Ship faster");
+  });
+
+  it("attaches stripe session and posthog ids", () => {
+    const out = prepareEvidenceForGenerate(validEvidence, {
+      stripeSessionId: "sess_123",
+      posthogDistinctId: "user-1",
+      posthogTraceId: "trace-1",
+    });
+    expect(out._stripe_session_id).toBe("sess_123");
+    expect(out.posthog_distinct_id).toBe("user-1");
+    expect(out.posthog_trace_id).toBe("trace-1");
+  });
+});
+
+describe("parseUrlRecovery", () => {
+  it("flags auth_failed and clears query", () => {
+    const replaceState = vi.fn();
+    const result = parseUrlRecovery({
+      search: "?error=auth_failed",
+      replaceState,
+    });
+    expect(result.authError).toBe(true);
+    expect(replaceState).toHaveBeenCalled();
+  });
+
+  it("persists premium stripe session from URL", () => {
+    const local = { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() };
+    const session = { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() };
+    parseUrlRecovery({
+      search: "?session_id=sess_abc&premium=1",
+      replaceState: vi.fn(),
+      storage: { local, session },
+    });
+    expect(local.setItem).toHaveBeenCalledWith("premium_stripe_session_id", "sess_abc");
+    expect(session.setItem).toHaveBeenCalledWith("stripe_session_id", "sess_abc");
+  });
+
+  it("loads merged evidence from session storage", () => {
+    const session = {
+      getItem: vi.fn(() => '{"merged":true}'),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    const result = parseUrlRecovery({
+      search: "?from_snapshot_merge=1",
+      replaceState: vi.fn(),
+      storage: { local: session, session },
+    });
+    expect(result.evidenceText).toBe('{"merged":true}');
+    expect(session.removeItem).toHaveBeenCalledWith("merged_evidence");
+  });
+});
+
+describe("recoverStripeReturnFromUrl", () => {
+  it("is a no-op when search has no stripe params", () => {
+    expect(
+      recoverStripeReturnFromUrl({
+        search: "",
+        replaceState: vi.fn(),
+        storage: {
+          local: { getItem: vi.fn(), setItem: vi.fn(), removeItem: vi.fn() },
+          session: { getItem: vi.fn(), setItem: vi.fn(), removeItem: vi.fn() },
+        },
+      })
+    ).toBeNull();
+  });
+});
+
+describe("recoverStripeAutoGenerate", () => {
+  it("returns saved session, evidence, and goals", () => {
+    const session = {
+      getItem: vi.fn((key: string) => {
+        if (key === "stripe_session_id") return "sess_1";
+        if (key === "premium_evidence") return JSON.stringify(validEvidence);
+        if (key === "premium_goals") return "Goal A";
+        return null;
+      }),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    const result = recoverStripeAutoGenerate({ session });
+    expect(result).toEqual({
+      sessionId: "sess_1",
+      evidenceText: JSON.stringify(validEvidence),
+      goals: "Goal A",
+    });
+    expect(session.removeItem).toHaveBeenCalledWith("stripe_session_id");
+    expect(session.removeItem).toHaveBeenCalledWith("premium_evidence");
+    expect(session.removeItem).toHaveBeenCalledWith("premium_goals");
+  });
+
+  it("returns null when stripe session is missing", () => {
+    const session = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    expect(recoverStripeAutoGenerate({ session })).toBeNull();
+  });
+});
+
+describe("runGenerate", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("polls async jobs and returns premium result metadata", async () => {
+    const pollJob = vi.fn().mockResolvedValue({ themes: [] });
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 202,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ job_id: "j1", premium: true, credits_remaining: 2 })
+          ),
+      } as Response);
+
+    const onProgress = vi.fn();
+    const capture = vi.fn();
+    const result = await runGenerate({
+      fetch,
+      parseJsonResponse: async (res: Response) => JSON.parse(await res.text()),
+      pollJob,
+      evidenceText: JSON.stringify(validEvidence),
+      goals: "",
+      onProgress,
+      posthog: { capture },
+    });
+
+    expect(pollJob).toHaveBeenCalledWith("j1", onProgress);
+    expect(result).toEqual({
+      ok: true,
+      result: { themes: [] },
+      isPremium: true,
+      creditsRemaining: 2,
+    });
+    expect(capture).toHaveBeenCalledWith("review_generate_completed", { premium: true });
+  });
+
+  it("returns validation error without calling fetch", async () => {
+    const result = await runGenerate({
+      fetch,
+      parseJsonResponse: async (res: Response) => JSON.parse(await res.text()),
+      pollJob: vi.fn(),
+      evidenceText: "bad",
+      goals: "",
+    });
+    expect(result).toEqual({ ok: false, error: expect.stringMatching(/invalid json/i) });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("maps PAYMENTS_NOT_CONFIGURED to friendly error", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: () =>
+        Promise.resolve(JSON.stringify({ code: PAYMENTS_NOT_CONFIGURED, error: "nope" })),
+    } as Response);
+
+    const result = await runGenerate({
+      fetch,
+      parseJsonResponse: async (res: Response) => JSON.parse(await res.text()),
+      pollJob: vi.fn(),
+      evidenceText: JSON.stringify(validEvidence),
+      goals: "",
+      stripeSessionId: "sess_1",
+      posthog: { capture: vi.fn() },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/not available in this environment/i);
+    }
+  });
+});
+
+describe("runPremiumCheckout", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects when evidence is missing", async () => {
+    const result = await runPremiumCheckout({
+      fetch,
+      parseJsonResponse: async (res: Response) => JSON.parse(await res.text()),
+      evidenceText: "bad",
+      goals: "",
+      session: { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() },
+    });
+    expect(result).toEqual({ ok: false, error: expect.stringMatching(/load your evidence/i) });
+  });
+
+  it("saves evidence and redirects to checkout url", async () => {
+    const session = { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() };
+    const assign = vi.fn();
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ url: "https://stripe.test/checkout" })),
+    } as Response);
+
+    const result = await runPremiumCheckout({
+      fetch,
+      parseJsonResponse: async (res: Response) => JSON.parse(await res.text()),
+      evidenceText: JSON.stringify(validEvidence),
+      goals: "Ship",
+      session,
+      redirect: assign,
+      posthog: { capture: vi.fn() },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(session.setItem).toHaveBeenCalledWith("premium_evidence", JSON.stringify(validEvidence));
+    expect(session.setItem).toHaveBeenCalledWith("premium_goals", "Ship");
+    expect(assign).toHaveBeenCalledWith("https://stripe.test/checkout");
+  });
+});
+
+describe("runSaveSnapshot", () => {
+  it("validates evidence before saving", async () => {
+    const saveSnapshot = vi.fn();
+    const result = await runSaveSnapshot({
+      evidenceText: "bad",
+      snapshotPeriod: "weekly",
+      snapshotLabel: "",
+      saveSnapshot,
+    });
+    expect(result).toEqual({ ok: false, error: expect.stringMatching(/invalid json/i) });
+    expect(saveSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("saves snapshot with parsed timeframe", async () => {
+    const saveSnapshot = vi.fn().mockResolvedValue("snap-1");
+    const result = await runSaveSnapshot({
+      evidenceText: JSON.stringify(validEvidence),
+      snapshotPeriod: "monthly",
+      snapshotLabel: "Q1",
+      saveSnapshot,
+    });
+    expect(result).toEqual({ ok: true, id: "snap-1" });
+    expect(saveSnapshot).toHaveBeenCalledWith({
+      period: "monthly",
+      start_date: "2025-01-01",
+      end_date: "2025-12-31",
+      evidence: validEvidence,
+      label: "Q1",
+    });
+  });
+});
+
+describe("fetch helpers", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetchPaymentsConfig returns defaults on failure", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("network"));
+    const config = await fetchPaymentsConfig(fetch);
+    expect(config.enabled).toBe(false);
+  });
+
+  it("fetchPremiumCredits returns account credits", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ credits: 3 })),
+    } as Response);
+    expect(await fetchPremiumCredits(fetch)).toBe(3);
+  });
+
+  it("fetchLatestJobEvidence returns stringified result", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(JSON.stringify({ latest: { status: "done", result: validEvidence } })),
+    } as Response);
+    const text = await fetchLatestJobEvidence(fetch);
+    expect(text).toBe(JSON.stringify(validEvidence, null, 2));
+  });
+
+  it("fetchSnapshotEvidence returns stringified evidence", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ evidence: validEvidence })),
+    } as Response);
+    const text = await fetchSnapshotEvidence(fetch, "snap-1");
+    expect(text).toBe(JSON.stringify(validEvidence, null, 2));
+  });
+});


### PR DESCRIPTION
## Summary
- Move generate-page workflow orchestration out of `Generate.tsx` into `src/workspaces/generate/` (validation, recovery, commands, and `useGenerateWorkspace` hook).
- `Generate.tsx` is now a rendering adapter that wires UI to workspace state and commands.
- Add 23 unit tests covering validation, URL/Stripe recovery, generate/premium/snapshot commands, and fetch helpers.

Closes #143

## Test plan
- [x] `yarn test` (421 tests pass)
- [x] `yarn build`
- [x] Existing `Generate.test.jsx` coverage still passes (27 tests)
- [x] New `test/generate-workspace.test.ts` covers key state transitions and commands


Made with [Cursor](https://cursor.com)