### PR TITLE
refactor: compose route modules from service objects (GH 128)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -123,6 +123,8 @@ function handleRequest(
   const log = (event: string, detail?: string): void =>
     console.error("[auth] " + event + (detail ? " " + detail : ""));
   const getSessionId = (r: IncomingMessage) => getSessionIdFromRequest(r, sessionSecret);
+  const session = { getSessionIdFromRequest: getSessionId, getSession };
+  const jobs = { createJob, runInBackground };
 
   if (path.startsWith("api/")) {
     const apiPath = path.slice(4);
@@ -175,56 +177,40 @@ function handleRequest(
 
     if (routeArea === "jobs") {
       jobsRoutes({
-        getSessionIdFromRequest: getSessionId,
-        getLatestJob,
-        getJob,
+        session,
+        jobs: { getLatestJob, getJob },
       })(wrappedReq, res, next);
       return;
     }
 
     if (routeArea === "generate") {
       generateRoutes({
-        validateEvidence,
-        createJob,
-        runInBackground,
-        runPipeline,
-        getSessionIdFromRequest: getSessionId,
-        getSession,
+        session,
+        jobs,
+        pipeline: { validateEvidence, runPipeline },
       })(wrappedReq, res, next);
       return;
     }
 
     if (routeArea === "payments") {
-      paymentsRoutes({
-        getSessionIdFromRequest: getSessionId,
-        getSession,
-      })(wrappedReq, res, next);
+      paymentsRoutes({ session })(wrappedReq, res, next);
       return;
     }
 
     if (routeArea === "collect") {
       collectRoutes({
-        getSessionIdFromRequest: getSessionId,
-        getSession,
-        createJob,
-        runInBackground,
-        intakeFromGitHub,
+        session,
+        jobs,
+        collect: { intakeFromGitHub },
       })(wrappedReq, res, next);
       return;
     }
     if (routeArea === "snapshots") {
-      snapshotsRoutes({
-        getSessionIdFromRequest: getSessionId,
-        getSession,
-      })(wrappedReq, res, next);
+      snapshotsRoutes({ session })(wrappedReq, res, next);
       return;
     }
     if (routeArea === "periodic") {
-      periodicRoutes({
-        getSessionIdFromRequest: getSessionId,
-        getSession,
-        intakeFromGitHub,
-      })(wrappedReq, res, next);
+      periodicRoutes({ session })(wrappedReq, res, next);
       return;
     }
   }

--- a/server/route-services.ts
+++ b/server/route-services.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared route-layer service objects injected into route modules.
+ */
+
+import type { IncomingMessage } from "http";
+import type { SessionData } from "../lib/session-store.js";
+
+export interface SessionService {
+  getSessionIdFromRequest: (req: IncomingMessage) => string | null;
+  getSession: (id: string) => SessionData | undefined;
+}
+
+export interface JobRunnerService {
+  createJob: (type: string, sessionId?: string) => string;
+  runInBackground: (
+    jobId: string,
+    fn: (report?: (data: { progress?: string }) => void) => void | Promise<unknown>
+  ) => void;
+}

--- a/server/routes/collect.ts
+++ b/server/routes/collect.ts
@@ -5,7 +5,6 @@
 
 import type { IncomingMessage, ServerResponse } from "http";
 import type { Evidence } from "../../types/evidence.js";
-import type { SessionData } from "../../lib/session-store.js";
 import {
   EvidenceIntakeError,
   intakeFromGitHub,
@@ -14,28 +13,24 @@ import {
   type IntakeFromGitHubOptions,
 } from "../../lib/evidence-intake.js";
 import { readJsonBody, respondJson } from "../helpers.js";
+import type { JobRunnerService, SessionService } from "../route-services.js";
+
+export interface CollectService {
+  intakeFromGitHub?: (opts: IntakeFromGitHubOptions) => Promise<Evidence>;
+}
 
 export interface CollectRoutesOptions {
-  getSessionIdFromRequest: (req: IncomingMessage) => string | null;
-  getSession: (id: string) => SessionData | undefined;
-  createJob: (type: string, sessionId?: string) => string;
-  runInBackground: (
-    jobId: string,
-    fn: () => void | Promise<unknown>
-  ) => void;
-  intakeFromGitHub?: (opts: IntakeFromGitHubOptions) => Promise<Evidence>;
+  session: SessionService;
+  jobs: JobRunnerService;
+  collect?: CollectService;
 }
 
 type Next = () => void;
 
 export function collectRoutes(options: CollectRoutesOptions) {
-  const {
-    getSessionIdFromRequest,
-    getSession,
-    createJob,
-    runInBackground,
-  } = options;
-  const runIntake = options.intakeFromGitHub ?? intakeFromGitHub;
+  const { session, jobs, collect = {} } = options;
+  const { createJob, runInBackground } = jobs;
+  const runIntake = collect.intakeFromGitHub ?? intakeFromGitHub;
 
   return async function collectMiddleware(
     req: IncomingMessage,
@@ -52,8 +47,8 @@ export function collectRoutes(options: CollectRoutesOptions) {
         end_date?: string;
         token?: string;
       };
-      const sessionId = getSessionIdFromRequest(req);
-      const session = sessionId ? getSession(sessionId) : undefined;
+      const sessionId = session.getSessionIdFromRequest(req);
+      const userSession = sessionId ? session.getSession(sessionId) : undefined;
       let start_date: string;
       let end_date: string;
       let token: string;
@@ -61,7 +56,7 @@ export function collectRoutes(options: CollectRoutesOptions) {
         ({ start_date, end_date } = parseTimeframe(body.start_date, body.end_date));
         token = resolveGitHubToken({
           body: body.token,
-          session: session?.access_token,
+          session: userSession?.access_token,
         });
       } catch (e) {
         if (e instanceof EvidenceIntakeError) {

--- a/server/routes/evidence-archive-helpers.ts
+++ b/server/routes/evidence-archive-helpers.ts
@@ -3,18 +3,17 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "http";
-import type { SessionData } from "../../lib/session-store.js";
+import type { SessionService } from "../route-services.js";
 import { respondJson } from "../helpers.js";
 
 export function createRequireLogin(
   req: IncomingMessage,
   res: ServerResponse,
-  getSessionIdFromRequest: (req: IncomingMessage) => string | null,
-  getSession: (id: string) => SessionData | undefined
+  sessionService: SessionService
 ): () => string | null {
   return () => {
-    const sessId = getSessionIdFromRequest(req);
-    const session = sessId ? getSession(sessId) : undefined;
+    const sessId = sessionService.getSessionIdFromRequest(req);
+    const session = sessId ? sessionService.getSession(sessId) : undefined;
     if (!session?.login) {
       respondJson(res, 401, { error: "Login required" });
       return null;

--- a/server/routes/generate.ts
+++ b/server/routes/generate.ts
@@ -15,36 +15,44 @@ import type { IncomingMessage, ServerResponse } from "http";
 import type { ValidationResult } from "../../lib/validate-evidence.js";
 import type { Evidence } from "../../types/evidence.js";
 import type { PipelineResult } from "../../lib/run-pipeline.js";
-import type { SessionData } from "../../lib/session-store.js";
-import { awardCredits as defaultAwardCredits, deductCredit as defaultDeductCredit, getCredits as defaultGetCredits, isCreditStoreConfigured as defaultIsPaymentsConfigured } from "../../lib/payment-store.js";
+import {
+  awardCredits as defaultAwardCredits,
+  deductCredit as defaultDeductCredit,
+  getCredits as defaultGetCredits,
+  isCreditStoreConfigured as defaultIsPaymentsConfigured,
+} from "../../lib/payment-store.js";
 import { PAYMENTS_NOT_CONFIGURED } from "../../lib/api-error-codes.js";
 import Stripe from "stripe";
 import { STRIPE_API_VERSION } from "../config.js";
-import { readJsonBody as defaultReadJsonBody, respondJson } from "../helpers.js";
+import { readJsonBody, respondJson } from "../helpers.js";
+import type { JobRunnerService, SessionService } from "../route-services.js";
 
-export interface GenerateRoutesOptions {
-  /** Injected in tests; defaults to streaming JSON from the request. */
-  readJsonBody?: (req: IncomingMessage) => Promise<object>;
+export interface GeneratePipelineService {
   validateEvidence: (evidence: unknown) => ValidationResult;
-  createJob: (type: string, sessionId?: string) => string;
-  runInBackground: (
-    jobId: string,
-    fn: (report: (data: { progress?: string }) => void) => void | Promise<unknown>
-  ) => void;
   runPipeline: (
     evidence: Evidence,
-    opts: { onProgress: (data: { stepIndex: number; total: number; label: string }) => void; premium?: boolean; posthogDistinctId?: string; posthogTraceId?: string }
+    opts: {
+      onProgress: (data: { stepIndex: number; total: number; label: string }) => void;
+      premium?: boolean;
+      posthogDistinctId?: string;
+      posthogTraceId?: string;
+    }
   ) => Promise<PipelineResult>;
-  getSessionIdFromRequest: (req: IncomingMessage) => string | null;
-  getSession: (id: string) => SessionData | undefined;
-  /** Optional injected Stripe client (for tests). */
+}
+
+export interface GeneratePaymentService {
   getStripe?: () => Stripe | null;
-  /** Check if payments/DB are configured (injectable for tests). */
   isPaymentsConfigured?: () => boolean;
-  /** Optional injected payment functions (for tests). */
   deductCredit?: (login: string) => Promise<boolean>;
   awardCredits?: (login: string, sessionId: string) => Promise<void>;
   getCredits?: (login: string) => Promise<number>;
+}
+
+export interface GenerateRoutesOptions {
+  session: SessionService;
+  jobs: JobRunnerService;
+  pipeline: GeneratePipelineService;
+  payments?: GeneratePaymentService;
 }
 
 type Next = () => void;
@@ -82,20 +90,14 @@ async function verifyAndAwardFromStripe(
 }
 
 export function generateRoutes(options: GenerateRoutesOptions) {
-  const {
-    validateEvidence,
-    createJob,
-    runInBackground,
-    runPipeline,
-    getSessionIdFromRequest,
-    getSession,
-    getStripe = defaultGetStripe,
-    isPaymentsConfigured = defaultIsPaymentsConfigured,
-    deductCredit = defaultDeductCredit,
-    awardCredits = defaultAwardCredits,
-    getCredits = defaultGetCredits,
-  } = options;
-  const readJsonBody = options.readJsonBody ?? defaultReadJsonBody;
+  const { session, jobs, pipeline, payments = {} } = options;
+  const { validateEvidence, runPipeline } = pipeline;
+  const { createJob, runInBackground } = jobs;
+  const getStripe = payments.getStripe ?? defaultGetStripe;
+  const isPaymentsConfigured = payments.isPaymentsConfigured ?? defaultIsPaymentsConfigured;
+  const deductCredit = payments.deductCredit ?? defaultDeductCredit;
+  const awardCredits = payments.awardCredits ?? defaultAwardCredits;
+  const getCredits = payments.getCredits ?? defaultGetCredits;
 
   return async function generateMiddleware(
     req: IncomingMessage,
@@ -138,7 +140,7 @@ export function generateRoutes(options: GenerateRoutesOptions) {
       let premium = false;
       let creditsRemaining: number | undefined;
 
-      const sessId = getSessionIdFromRequest(req);
+      const sessId = session.getSessionIdFromRequest(req);
 
       if (wantsPremium) {
         if (!isPaymentsConfigured()) {
@@ -146,7 +148,7 @@ export function generateRoutes(options: GenerateRoutesOptions) {
           return;
         }
         // Must be logged in — credits are tied to a GitHub account
-        const userSession = sessId ? getSession(sessId) : undefined;
+        const userSession = sessId ? session.getSession(sessId) : undefined;
         if (!userSession?.login) {
           respondJson(res, 401, { error: "Login required for premium generation" });
           return;
@@ -181,7 +183,7 @@ export function generateRoutes(options: GenerateRoutesOptions) {
           posthogDistinctId,
           posthogTraceId,
           onProgress: ({ stepIndex, total, label }) =>
-            report({ progress: `${stepIndex}/${total} ${label}` }),
+            report?.({ progress: `${stepIndex}/${total} ${label}` }),
         })
       );
       respondJson(res, 202, {

--- a/server/routes/jobs.ts
+++ b/server/routes/jobs.ts
@@ -6,17 +6,23 @@
 import type { IncomingMessage, ServerResponse } from "http";
 import type { Job } from "../../lib/job-store.js";
 import { respondJson } from "../helpers.js";
+import type { SessionService } from "../route-services.js";
 
-export interface JobsRoutesOptions {
-  getSessionIdFromRequest: (req: IncomingMessage) => string | null;
+export interface JobsService {
   getLatestJob: (sessionId: string) => (Job & { id: string }) | null;
   getJob: (id: string) => Job | undefined;
+}
+
+export interface JobsRoutesOptions {
+  session: SessionService;
+  jobs: JobsService;
 }
 
 type Next = () => void;
 
 export function jobsRoutes(options: JobsRoutesOptions) {
-  const { getSessionIdFromRequest, getLatestJob, getJob } = options;
+  const { session, jobs } = options;
+  const { getLatestJob, getJob } = jobs;
 
   return function jobsMiddleware(
     req: IncomingMessage,
@@ -29,7 +35,7 @@ export function jobsRoutes(options: JobsRoutesOptions) {
     }
     const path = (req.url?.split("?")[0] || "").replace(/^\/+/, "") || "";
     if (!path) {
-      const sessionId = getSessionIdFromRequest(req);
+      const sessionId = session.getSessionIdFromRequest(req);
       const latest = sessionId ? getLatestJob(sessionId) : null;
       respondJson(res, 200, latest ? { latest } : { latest: null });
       return;

--- a/server/routes/payments.ts
+++ b/server/routes/payments.ts
@@ -9,20 +9,22 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "http";
-import type { SessionData } from "../../lib/session-store.js";
 import Stripe from "stripe";
 import { awardCredits, getCredits, getCreditsPerPurchase } from "../../lib/payment-store.js";
 import { getDefaultModels } from "../../lib/narrative-model-runner.js";
 import { STRIPE_API_VERSION } from "../config.js";
 import { respondJson } from "../helpers.js";
+import type { SessionService } from "../route-services.js";
 
-export interface PaymentsRoutesOptions {
+export interface PaymentsService {
   getStripe?: () => Stripe | null;
-  getSessionIdFromRequest: (req: IncomingMessage) => string | null;
-  getSession: (id: string) => SessionData | undefined;
-  /** Optional for tests; when not provided uses real payment store (requires DATABASE_URL). */
   awardCredits?: (userLogin: string, sessionId: string) => Promise<void>;
   getCredits?: (userLogin: string) => Promise<number>;
+}
+
+export interface PaymentsRoutesOptions {
+  session: SessionService;
+  payments?: PaymentsService;
 }
 
 type Next = () => void;
@@ -44,13 +46,10 @@ function getStripeClient(): Stripe | null {
 }
 
 export function paymentsRoutes(options: PaymentsRoutesOptions) {
-  const {
-    getStripe = getStripeClient,
-    getSessionIdFromRequest,
-    getSession,
-    awardCredits: awardCreditsFn = awardCredits,
-    getCredits: getCreditsFn = getCredits,
-  } = options;
+  const { session, payments = {} } = options;
+  const getStripe = payments.getStripe ?? getStripeClient;
+  const awardCreditsFn = payments.awardCredits ?? awardCredits;
+  const getCreditsFn = payments.getCredits ?? getCredits;
 
   return async function paymentsMiddleware(
     req: IncomingMessage,
@@ -74,8 +73,8 @@ export function paymentsRoutes(options: PaymentsRoutesOptions) {
 
     // GET /credits or GET /credits/:anything – returns remaining credits for the logged-in user
     if ((path === "credits" || path.startsWith("credits/")) && req.method === "GET") {
-      const sessId = getSessionIdFromRequest(req);
-      const userSession = sessId ? getSession(sessId) : undefined;
+      const sessId = session.getSessionIdFromRequest(req);
+      const userSession = sessId ? session.getSession(sessId) : undefined;
       if (!userSession?.login) {
         respondJson(res, 401, { error: "Login required" });
         return;
@@ -90,8 +89,8 @@ export function paymentsRoutes(options: PaymentsRoutesOptions) {
         return;
       }
       // Require the user to be logged in before purchasing credits
-      const sessId = getSessionIdFromRequest(req);
-      const userSession = sessId ? getSession(sessId) : undefined;
+      const sessId = session.getSessionIdFromRequest(req);
+      const userSession = sessId ? session.getSession(sessId) : undefined;
       if (!userSession?.login) {
         respondJson(res, 401, { error: "Login required to purchase premium credits" });
         return;

--- a/server/routes/periodic.ts
+++ b/server/routes/periodic.ts
@@ -14,7 +14,6 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "http";
-import type { SessionData } from "../../lib/session-store.js";
 import type { Evidence } from "../../types/evidence.js";
 import {
   EvidenceIntakeError,
@@ -36,32 +35,34 @@ import {
   weekEnd,
 } from "../../lib/evidence-archive/period.js";
 import { tryParseJson } from "../../lib/evidence-archive/json.js";
-import { readJsonBody as defaultReadJsonBody, respondJson } from "../helpers.js";
+import { readJsonBody, respondJson } from "../helpers.js";
+import type { SessionService } from "../route-services.js";
 import {
   createRequireLogin,
   readJsonBodyOrRespond400,
   requireEvidenceArchiveConfigured,
 } from "./evidence-archive-helpers.js";
 
+export interface PeriodicService {
+  intakeFromGitHub: (opts: IntakeFromGitHubOptions) => Promise<Evidence>;
+  runDailySummary: (evidence: Evidence) => Promise<string>;
+  runWeeklyRollup: (weekStart: string, weekEnd: string, dailyJsons: string[]) => Promise<string>;
+  runMonthlyRollup: (month: string, weeklyJsons: string[]) => Promise<string>;
+  saveDailySummary: (userLogin: string, date: string, evidence: Evidence, summary: string) => Promise<string>;
+  saveWeeklyRollup: (userLogin: string, weekStartDate: string, childIds: string[], summary: string, totalContributions: number) => Promise<string>;
+  saveMonthlyRollup: (userLogin: string, month: string, childIds: string[], summary: string, totalContributions: number) => Promise<string>;
+  getPeriodicSummary: (id: string, userLogin: string) => Promise<PeriodicSummaryWithEvidence | null>;
+  listPeriodicSummaries: (userLogin: string, periodType?: PeriodType, limit?: number) => Promise<PeriodicSummary[]>;
+  getDailySummariesForWeek: (userLogin: string, weekStartDate: string) => Promise<PeriodicSummaryWithEvidence[]>;
+  getWeeklySummariesForMonth: (userLogin: string, month: string) => Promise<PeriodicSummary[]>;
+  deletePeriodicSummary: (id: string, userLogin: string) => Promise<boolean>;
+  isPeriodicStoreConfigured: () => boolean;
+}
+
 export interface PeriodicRoutesOptions {
-  /** Injected in tests; defaults to streaming JSON from the request. */
-  readJsonBody?: (req: IncomingMessage) => Promise<object>;
-  getSessionIdFromRequest: (req: IncomingMessage) => string | null;
-  getSession: (id: string) => SessionData | undefined;
-  intakeFromGitHub?: (opts: IntakeFromGitHubOptions) => Promise<Evidence>;
-  /** Injected for tests */
-  runDailySummary?: (evidence: Evidence) => Promise<string>;
-  runWeeklyRollup?: (weekStart: string, weekEnd: string, dailyJsons: string[]) => Promise<string>;
-  runMonthlyRollup?: (month: string, weeklyJsons: string[]) => Promise<string>;
-  saveDailySummary?: (userLogin: string, date: string, evidence: Evidence, summary: string) => Promise<string>;
-  saveWeeklyRollup?: (userLogin: string, weekStartDate: string, childIds: string[], summary: string, totalContributions: number) => Promise<string>;
-  saveMonthlyRollup?: (userLogin: string, month: string, childIds: string[], summary: string, totalContributions: number) => Promise<string>;
-  getPeriodicSummary?: (id: string, userLogin: string) => Promise<PeriodicSummaryWithEvidence | null>;
-  listPeriodicSummaries?: (userLogin: string, periodType?: PeriodType, limit?: number) => Promise<PeriodicSummary[]>;
-  getDailySummariesForWeek?: (userLogin: string, weekStartDate: string) => Promise<PeriodicSummaryWithEvidence[]>;
-  getWeeklySummariesForMonth?: (userLogin: string, month: string) => Promise<PeriodicSummary[]>;
-  deletePeriodicSummary?: (id: string, userLogin: string) => Promise<boolean>;
-  isPeriodicStoreConfigured?: () => boolean;
+  session: SessionService;
+  /** Injected in tests; production uses periodic-store and pipeline adapters. */
+  periodic?: PeriodicService;
 }
 
 type Next = () => void;
@@ -70,47 +71,17 @@ const DEFAULT_SUMMARIES_LIMIT = 90;
 const MAX_SUMMARIES_LIMIT = 365;
 
 export function periodicRoutes(options: PeriodicRoutesOptions) {
-  const { getSessionIdFromRequest, getSession } = options;
-  const readJsonBody = options.readJsonBody ?? defaultReadJsonBody;
-  const runIntake = options.intakeFromGitHub ?? intakeFromGitHub;
+  const { session } = options;
 
-  async function getStore() {
-    const allProvided =
-      options.runDailySummary &&
-      options.runWeeklyRollup &&
-      options.runMonthlyRollup &&
-      options.saveDailySummary &&
-      options.saveWeeklyRollup &&
-      options.saveMonthlyRollup &&
-      options.getPeriodicSummary &&
-      options.listPeriodicSummaries &&
-      options.getDailySummariesForWeek &&
-      options.getWeeklySummariesForMonth &&
-      options.deletePeriodicSummary &&
-      options.isPeriodicStoreConfigured;
-
-    if (allProvided) {
-      return {
-        runDailySummary: options.runDailySummary!,
-        runWeeklyRollup: options.runWeeklyRollup!,
-        runMonthlyRollup: options.runMonthlyRollup!,
-        saveDailySummary: options.saveDailySummary!,
-        saveWeeklyRollup: options.saveWeeklyRollup!,
-        saveMonthlyRollup: options.saveMonthlyRollup!,
-        getPeriodicSummary: options.getPeriodicSummary!,
-        listPeriodicSummaries: options.listPeriodicSummaries!,
-        getDailySummariesForWeek: options.getDailySummariesForWeek!,
-        getWeeklySummariesForMonth: options.getWeeklySummariesForMonth!,
-        deletePeriodicSummary: options.deletePeriodicSummary!,
-        isPeriodicStoreConfigured: options.isPeriodicStoreConfigured!,
-      };
-    }
+  async function getStore(): Promise<PeriodicService> {
+    if (options.periodic) return options.periodic;
 
     const [store, pipeline] = await Promise.all([
       import("../../lib/evidence-archive/periodic-adapter.js"),
       import("../../lib/run-periodic-pipeline.js"),
     ]);
     return {
+      intakeFromGitHub,
       runDailySummary: pipeline.runDailySummary,
       runWeeklyRollup: pipeline.runWeeklyRollup,
       runMonthlyRollup: pipeline.runMonthlyRollup,
@@ -131,12 +102,7 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
     res: ServerResponse,
     next: Next
   ): Promise<void> {
-    const requireLogin = createRequireLogin(
-      req,
-      res,
-      getSessionIdFromRequest,
-      getSession
-    );
+    const requireLogin = createRequireLogin(req, res, session);
     const rawPath = (req.url?.split("?")[0] || "").replace(/^\/+/, "") || "";
     const queryString = req.url?.split("?")[1] ?? "";
     const params = new URLSearchParams(queryString);
@@ -163,8 +129,8 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
       const date = (body.date as string | undefined) ??
         new Date().toISOString().slice(0, 10);
 
-      const sessId = getSessionIdFromRequest(req);
-      const session = sessId ? getSession(sessId) : undefined;
+      const sessId = session.getSessionIdFromRequest(req);
+      const userSession = sessId ? session.getSession(sessId) : undefined;
       let start_date: string;
       let end_date: string;
       let token: string;
@@ -172,7 +138,7 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
         ({ start_date, end_date } = parseTimeframe(date, date));
         token = resolveGitHubToken({
           body: body.token,
-          session: session?.access_token,
+          session: userSession?.access_token,
         });
       } catch (e) {
         if (e instanceof EvidenceIntakeError) {
@@ -184,7 +150,7 @@ export function periodicRoutes(options: PeriodicRoutesOptions) {
       }
 
       try {
-        const evidence = await runIntake({ token, start_date, end_date });
+        const evidence = await store.intakeFromGitHub({ token, start_date, end_date });
         const summaryJson = await store.runDailySummary(evidence);
         const id = await store.saveDailySummary(userLogin, date, evidence, summaryJson);
         respondJson(res, 201, {

--- a/server/routes/snapshots.ts
+++ b/server/routes/snapshots.ts
@@ -8,7 +8,6 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "http";
-import type { SessionData } from "../../lib/session-store.js";
 import type { Evidence } from "../../types/evidence.js";
 import type {
   Snapshot,
@@ -19,20 +18,16 @@ import {
   DATE_YYYY_MM_DD,
   SNAPSHOT_PERIODS,
 } from "../../lib/evidence-archive/period.js";
-import { readJsonBody as defaultReadJsonBody, respondJson } from "../helpers.js";
+import { readJsonBody, respondJson } from "../helpers.js";
+import type { SessionService } from "../route-services.js";
 import {
   createRequireLogin,
   readJsonBodyOrRespond400,
   requireEvidenceArchiveConfigured,
 } from "./evidence-archive-helpers.js";
 
-export interface SnapshotsRoutesOptions {
-  /** Injected in tests; defaults to streaming JSON from the request. */
-  readJsonBody?: (req: IncomingMessage) => Promise<object>;
-  getSessionIdFromRequest: (req: IncomingMessage) => string | null;
-  getSession: (id: string) => SessionData | undefined;
-  /** Injected for tests; defaults to real snapshot-store functions when not provided. */
-  saveSnapshot?: (
+export interface SnapshotService {
+  saveSnapshot: (
     userLogin: string,
     period: SnapshotPeriod,
     startDate: string,
@@ -40,18 +35,23 @@ export interface SnapshotsRoutesOptions {
     evidence: Evidence,
     label?: string
   ) => Promise<string>;
-  listSnapshots?: (userLogin: string) => Promise<Snapshot[]>;
-  getSnapshot?: (id: string, userLogin: string) => Promise<SnapshotWithEvidence | null>;
-  deleteSnapshot?: (id: string, userLogin: string) => Promise<boolean>;
-  mergeSnapshots?: (ids: string[], userLogin: string) => Promise<Evidence | null>;
-  isSnapshotStoreConfigured?: () => boolean;
+  listSnapshots: (userLogin: string) => Promise<Snapshot[]>;
+  getSnapshot: (id: string, userLogin: string) => Promise<SnapshotWithEvidence | null>;
+  deleteSnapshot: (id: string, userLogin: string) => Promise<boolean>;
+  mergeSnapshots: (ids: string[], userLogin: string) => Promise<Evidence | null>;
+  isSnapshotStoreConfigured: () => boolean;
+}
+
+export interface SnapshotsRoutesOptions {
+  session: SessionService;
+  /** Injected in tests; production uses the snapshot-store adapter. */
+  snapshots?: SnapshotService;
 }
 
 type Next = () => void;
 
 export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
-  const { getSessionIdFromRequest, getSession } = options;
-  const readJsonBody = options.readJsonBody ?? defaultReadJsonBody;
+  const { session } = options;
 
   return async function snapshotsMiddleware(
     req: IncomingMessage,
@@ -59,31 +59,10 @@ export function snapshotsRoutes(options: SnapshotsRoutesOptions) {
     next: Next
   ): Promise<void> {
     const rawPath = (req.url?.split("?")[0] || "").replace(/^\/+/, "") || "";
-    const requireLogin = createRequireLogin(
-      req,
-      res,
-      getSessionIdFromRequest,
-      getSession
-    );
+    const requireLogin = createRequireLogin(req, res, session);
 
-    async function getStore() {
-      if (
-        options.saveSnapshot &&
-        options.listSnapshots &&
-        options.getSnapshot &&
-        options.deleteSnapshot &&
-        options.mergeSnapshots &&
-        options.isSnapshotStoreConfigured
-      ) {
-        return {
-          saveSnapshot: options.saveSnapshot,
-          listSnapshots: options.listSnapshots,
-          getSnapshot: options.getSnapshot,
-          deleteSnapshot: options.deleteSnapshot,
-          mergeSnapshots: options.mergeSnapshots,
-          isSnapshotStoreConfigured: options.isSnapshotStoreConfigured,
-        };
-      }
+    async function getStore(): Promise<SnapshotService> {
+      if (options.snapshots) return options.snapshots;
       const store = await import("../../lib/evidence-archive/snapshots-adapter.js");
       return {
         saveSnapshot: store.saveSnapshot,

--- a/test/generate-premium.test.js
+++ b/test/generate-premium.test.js
@@ -1,30 +1,95 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { generateRoutes } from "../server/routes/generate.ts";
 import { PAYMENTS_NOT_CONFIGURED } from "../lib/api-error-codes.ts";
-import { mockRes, respondJson } from "./helpers.js";
+import * as helpers from "../server/helpers.ts";
+import { mockRes, mockReq } from "./helpers.js";
 
 const validEvidence = {
   timeframe: { start_date: "2025-01-01", end_date: "2025-12-31" },
   contributions: [],
 };
 
+function postReq(body = validEvidence) {
+  return mockReq("POST", "/", body);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 /** Build default options (not logged in). */
 function makeOptions(overrides = {}) {
   const runPipeline = vi.fn().mockResolvedValue({ themes: {}, bullets: {}, stories: {}, self_eval: {} });
   const createJob = vi.fn().mockReturnValue("job-1");
   const runInBackground = vi.fn((jobId, fn) => fn(() => {}));
-  return {
-    readJsonBody: vi.fn().mockResolvedValue({ ...validEvidence }),
-    respondJson,
-    validateEvidence: (ev) => ({ valid: !!ev?.timeframe?.start_date }),
-    createJob,
-    runInBackground,
-    runPipeline,
-    getStripe: () => null,
-    getSessionIdFromRequest: vi.fn().mockReturnValue(null),
-    getSession: vi.fn().mockReturnValue(undefined),
-    ...overrides,
+
+  const {
+    readJsonBody: _readJsonBody,
+    validateEvidence,
+    createJob: createJobOverride,
+    runInBackground: runInBackgroundOverride,
+    runPipeline: runPipelineOverride,
+    getSessionIdFromRequest,
+    getSession,
+    getStripe,
+    isPaymentsConfigured,
+    deductCredit,
+    awardCredits,
+    getCredits,
+    session: sessionOverrides,
+    jobs: jobsOverrides,
+    pipeline: pipelineOverrides,
+    payments: paymentsOverrides,
+    ...rest
+  } = overrides;
+
+  const options = {
+    session: {
+      getSessionIdFromRequest: vi.fn().mockReturnValue(null),
+      getSession: vi.fn().mockReturnValue(undefined),
+      ...(getSessionIdFromRequest !== undefined ? { getSessionIdFromRequest } : {}),
+      ...(getSession !== undefined ? { getSession } : {}),
+      ...(sessionOverrides || {}),
+    },
+    jobs: {
+      createJob,
+      runInBackground,
+      ...(createJobOverride ? { createJob: createJobOverride } : {}),
+      ...(runInBackgroundOverride ? { runInBackground: runInBackgroundOverride } : {}),
+      ...(jobsOverrides || {}),
+    },
+    pipeline: {
+      validateEvidence: (ev) => ({ valid: !!ev?.timeframe?.start_date }),
+      runPipeline,
+      ...(validateEvidence ? { validateEvidence } : {}),
+      ...(runPipelineOverride ? { runPipeline: runPipelineOverride } : {}),
+      ...(pipelineOverrides || {}),
+    },
+    ...rest,
   };
+
+  const paymentFields = {
+    ...(getStripe !== undefined ? { getStripe } : {}),
+    ...(isPaymentsConfigured ? { isPaymentsConfigured } : {}),
+    ...(deductCredit ? { deductCredit } : {}),
+    ...(awardCredits ? { awardCredits } : {}),
+    ...(getCredits ? { getCredits } : {}),
+    ...(paymentsOverrides || {}),
+  };
+  if (Object.keys(paymentFields).length > 0) {
+    options.payments = paymentFields;
+  }
+
+  options.createJob = options.jobs.createJob;
+  options.runInBackground = options.jobs.runInBackground;
+  options.runPipeline = options.pipeline.runPipeline;
+  if (options.payments) Object.assign(options, options.payments);
+
+  if (_readJsonBody) {
+    vi.spyOn(helpers, "readJsonBody").mockImplementation(_readJsonBody);
+  }
+
+  return options;
 }
 
 /** Build options with a logged-in user. */
@@ -32,8 +97,6 @@ function makeOptionsLoggedIn(login, overrides = {}) {
   return makeOptions({
     getSessionIdFromRequest: vi.fn().mockReturnValue("sess_test"),
     getSession: vi.fn().mockReturnValue({ login, access_token: "tok", created_at: "2025-01-01" }),
-    // Payment functions default to "configured but no credits" so tests that don't
-    // explicitly care about the payment layer still work without DATABASE_URL.
     isPaymentsConfigured: () => true,
     deductCredit: vi.fn().mockResolvedValue(false),
     getCredits: vi.fn().mockResolvedValue(0),
@@ -45,12 +108,11 @@ function makeOptionsLoggedIn(login, overrides = {}) {
 describe("generateRoutes – payments not configured", () => {
   it("returns 503 with PAYMENTS_NOT_CONFIGURED when wantsPremium but DB is absent", async () => {
     const opts = makeOptionsLoggedIn("alice", {
-      readJsonBody: vi.fn().mockResolvedValue({ ...validEvidence, _premium: true }),
       isPaymentsConfigured: () => false,
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq({ ...validEvidence, _premium: true }), res, () => {});
     expect(res.statusCode).toBe(503);
     expect(res.body).toMatchObject({ error: "Premium is not available", code: PAYMENTS_NOT_CONFIGURED });
     expect(opts.runPipeline).not.toHaveBeenCalled();
@@ -58,12 +120,11 @@ describe("generateRoutes – payments not configured", () => {
 
   it("returns 503 with PAYMENTS_NOT_CONFIGURED when _stripe_session_id sent but DB is absent", async () => {
     const opts = makeOptionsLoggedIn("alice", {
-      readJsonBody: vi.fn().mockResolvedValue({ ...validEvidence, _stripe_session_id: "cs_test" }),
       isPaymentsConfigured: () => false,
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq({ ...validEvidence, _stripe_session_id: "cs_test" }), res, () => {});
     expect(res.statusCode).toBe(503);
     expect(res.body).toMatchObject({ error: "Premium is not available", code: PAYMENTS_NOT_CONFIGURED });
     expect(opts.runPipeline).not.toHaveBeenCalled();
@@ -74,7 +135,7 @@ describe("generateRoutes – payments not configured", () => {
       getSessionIdFromRequest: vi.fn().mockReturnValue("sess_anon"),
     });
     const handler = generateRoutes(opts);
-    const req = { method: "POST", url: "/" };
+    const req = postReq();
     const res = mockRes();
     await handler(req, res, () => {});
     expect(opts.createJob).toHaveBeenCalledWith("generate", "sess_anon");
@@ -88,7 +149,7 @@ describe("generateRoutes – error and progress paths", () => {
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq(), res, () => {});
     expect(res.statusCode).toBe(500);
     expect(res.body.error).toBe("network failure");
   });
@@ -99,7 +160,7 @@ describe("generateRoutes – error and progress paths", () => {
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq(), res, () => {});
     expect(res.statusCode).toBe(500);
     expect(res.body.error).toBe("Pipeline failed");
   });
@@ -128,7 +189,7 @@ describe("generateRoutes – error and progress paths", () => {
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq(), res, () => {});
     expect(capturedReport).toHaveBeenCalledWith({ progress: "1/3 themes" });
   });
 });
@@ -136,13 +197,12 @@ describe("generateRoutes – error and progress paths", () => {
 describe("generateRoutes – premium paths (mocked payment functions)", () => {
   it("returns 401 when wantsPremium, payments configured, but user not logged in", async () => {
     const opts = makeOptions({
-      readJsonBody: vi.fn().mockResolvedValue({ ...validEvidence, _premium: true }),
       isPaymentsConfigured: () => true,
       getSessionIdFromRequest: vi.fn().mockReturnValue(null),
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq({ ...validEvidence, _premium: true }), res, () => {});
     expect(res.statusCode).toBe(401);
     expect(res.body.error).toMatch(/login required/i);
     expect(opts.runPipeline).not.toHaveBeenCalled();
@@ -157,7 +217,7 @@ describe("generateRoutes – premium paths (mocked payment functions)", () => {
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq(), res, () => {});
     expect(res.statusCode).toBe(402);
     expect(res.body.error).toMatch(/no premium credits/i);
     expect(opts.runPipeline).not.toHaveBeenCalled();
@@ -185,7 +245,7 @@ describe("generateRoutes – premium paths (mocked payment functions)", () => {
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq(), res, () => {});
     expect(res.statusCode).toBe(402);
     expect(res.body.error).toMatch(/payment required/i);
     expect(opts.runPipeline).not.toHaveBeenCalled();
@@ -202,7 +262,7 @@ describe("generateRoutes – premium paths (mocked payment functions)", () => {
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq(), res, () => {});
     expect(res.statusCode).toBe(402);
     expect(res.body.error).toMatch(/payment required/i);
     expect(opts.runPipeline).not.toHaveBeenCalled();
@@ -217,7 +277,7 @@ describe("generateRoutes – premium paths (mocked payment functions)", () => {
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq(), res, () => {});
     expect(res.statusCode).toBe(202);
     expect(res.body).toMatchObject({ job_id: "job-1", premium: true, credits_remaining: 4 });
     expect(opts.createJob).toHaveBeenCalledWith("generate-premium", "sess_test");
@@ -253,7 +313,7 @@ describe("generateRoutes – premium paths (mocked payment functions)", () => {
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq(), res, () => {});
     expect(res.statusCode).toBe(202);
     expect(res.body).toMatchObject({ premium: true });
     expect(mockAwardCredits).toHaveBeenCalledWith("carol", "cs_new");
@@ -278,7 +338,7 @@ describe("generateRoutes – premium paths (mocked payment functions)", () => {
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq(), res, () => {});
     expect(res.statusCode).toBe(402);
     expect(res.body.error).toMatch(/payment required/i);
   });
@@ -288,7 +348,7 @@ describe("generateRoutes – premium flag", () => {
   it("runs free pipeline when no stripe_session_id and no _premium flag", async () => {
     const opts = makeOptions();
     const handler = generateRoutes(opts);
-    const req = { method: "POST", url: "/" };
+    const req = postReq();
     const res = mockRes();
     await handler(req, res, () => {});
     expect(opts.createJob).toHaveBeenCalledWith("generate", undefined);
@@ -307,7 +367,7 @@ describe("generateRoutes – premium flag", () => {
       getCredits: vi.fn().mockResolvedValue(0),
     });
     const handler = generateRoutes(opts);
-    const req = { method: "POST", url: "/" };
+    const req = postReq();
     const res = mockRes();
     await handler(req, res, () => {});
     expect(opts.createJob).toHaveBeenCalledWith("generate-premium", "sess_test");
@@ -319,7 +379,7 @@ describe("generateRoutes – premium flag", () => {
       isPaymentsConfigured: () => true,
     });
     const handler = generateRoutes(opts);
-    const req = { method: "POST", url: "/" };
+    const req = postReq();
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(401);
@@ -346,7 +406,7 @@ describe("generateRoutes – premium flag", () => {
       }),
     });
     const handler = generateRoutes(opts);
-    const req = { method: "POST", url: "/" };
+    const req = postReq();
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(402);
@@ -364,7 +424,7 @@ describe("generateRoutes – premium flag", () => {
       getCredits: vi.fn().mockResolvedValue(0),
     });
     const handler = generateRoutes(opts);
-    const req = { method: "POST", url: "/" };
+    const req = postReq();
     const res = mockRes();
     await handler(req, res, () => {});
     expect(opts.createJob).toHaveBeenCalledWith("generate-premium", "sess_test");
@@ -383,7 +443,7 @@ describe("generateRoutes – premium flag", () => {
       getCredits: vi.fn().mockResolvedValue(0),
     });
     const handler = generateRoutes(opts);
-    const req = { method: "POST", url: "/" };
+    const req = postReq();
     const res = mockRes();
     await handler(req, res, () => {});
     expect(opts.createJob).toHaveBeenCalledWith("generate-premium", "sess_test");
@@ -411,7 +471,7 @@ describe("generateRoutes – premium flag", () => {
       getCredits: vi.fn().mockResolvedValue(0),
     });
     const handler = generateRoutes(opts);
-    const req = { method: "POST", url: "/" };
+    const req = postReq();
     const res = mockRes();
     await handler(req, res, () => {});
     expect(mockAwardCredits).toHaveBeenCalledWith("carol", "cs_new");
@@ -439,7 +499,7 @@ describe("generateRoutes – premium flag", () => {
       awardCredits: vi.fn().mockResolvedValue(undefined),
     });
     const handler = generateRoutes(opts);
-    const req = { method: "POST", url: "/" };
+    const req = postReq();
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(402);
@@ -454,10 +514,10 @@ describe("generateRoutes – premium flag", () => {
     });
     const handler = generateRoutes(opts);
     const res1 = mockRes();
-    await handler({ method: "POST", url: "/" }, res1, () => {});
+    await handler(postReq(), res1, () => {});
     expect(res1.statusCode).toBe(202);
     const res2 = mockRes();
-    await handler({ method: "POST", url: "/" }, res2, () => {});
+    await handler(postReq(), res2, () => {});
     expect(res2.statusCode).toBe(402);
     expect(res2.body.error).toMatch(/no premium credits/i);
   });
@@ -476,7 +536,7 @@ describe("generateRoutes – premium flag", () => {
         return Promise.resolve({ themes: {}, bullets: {}, stories: {}, self_eval: {} });
       }),
     });
-    await generateRoutes(opts)({ method: "POST", url: "/" }, mockRes(), () => {});
+    await generateRoutes(opts)(postReq(), mockRes(), () => {});
     expect(capturedEvidence).toBeDefined();
     expect(capturedEvidence).not.toHaveProperty("_stripe_session_id");
     expect(capturedEvidence).not.toHaveProperty("_premium");
@@ -492,7 +552,7 @@ describe("generateRoutes – premium flag", () => {
     });
     const handler = generateRoutes(opts);
     const res = mockRes();
-    await handler({ method: "POST", url: "/" }, res, () => {});
+    await handler(postReq(), res, () => {});
     expect(res.statusCode).toBe(202);
     expect(opts.runPipeline).toHaveBeenCalledWith(
       expect.anything(),
@@ -516,7 +576,7 @@ describe("generateRoutes – premium flag", () => {
         return Promise.resolve({ themes: {}, bullets: {}, stories: {}, self_eval: {} });
       }),
     });
-    await generateRoutes(opts)({ method: "POST", url: "/" }, mockRes(), () => {});
+    await generateRoutes(opts)(postReq(), mockRes(), () => {});
     expect(capturedEvidence).toBeDefined();
     expect(capturedEvidence).not.toHaveProperty("posthog_distinct_id");
     expect(capturedEvidence).not.toHaveProperty("posthog_trace_id");
@@ -525,7 +585,7 @@ describe("generateRoutes – premium flag", () => {
   it("omits posthogDistinctId and posthogTraceId from runPipeline when not provided", async () => {
     const opts = makeOptions();
     const handler = generateRoutes(opts);
-    await handler({ method: "POST", url: "/" }, mockRes(), () => {});
+    await handler(postReq(), mockRes(), () => {});
     expect(opts.runPipeline).toHaveBeenCalledWith(
       expect.anything(),
       expect.not.objectContaining({

--- a/test/payments.test.js
+++ b/test/payments.test.js
@@ -1,15 +1,34 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getCreditsPerPurchase } from "../lib/payment-store.ts";
 import { paymentsRoutes } from "../server/routes/payments.ts";
-import { mockRes, mockReq, respondJson } from "./helpers.js";
+import { mockRes, mockReq } from "./helpers.js";
 
 function makeRouteOptions(overrides = {}) {
+  const {
+    getSessionIdFromRequest,
+    getSession,
+    getStripe,
+    awardCredits,
+    getCredits,
+    session: sessionOverrides,
+    payments: paymentsOverrides,
+  } = overrides;
+
   return {
-    respondJson,
-    getStripe: () => null,
-    getSessionIdFromRequest: () => null,
-    getSession: () => undefined,
-    ...overrides,
+    session: {
+      getSessionIdFromRequest: () => null,
+      getSession: () => undefined,
+      ...(getSessionIdFromRequest !== undefined ? { getSessionIdFromRequest } : {}),
+      ...(getSession !== undefined ? { getSession } : {}),
+      ...(sessionOverrides || {}),
+    },
+    payments: {
+      getStripe: () => null,
+      ...(getStripe !== undefined ? { getStripe } : {}),
+      ...(awardCredits ? { awardCredits } : {}),
+      ...(getCredits ? { getCredits } : {}),
+      ...(paymentsOverrides || {}),
+    },
   };
 }
 

--- a/test/routes-collect.test.js
+++ b/test/routes-collect.test.js
@@ -3,14 +3,46 @@ import { collectRoutes } from "../server/routes/collect.ts";
 import { mockRes, mockReq } from "./helpers.js";
 
 function makeOptions(overrides = {}) {
-  return {
-    getSessionIdFromRequest: () => null,
-    getSession: () => undefined,
+  const {
+    getSessionIdFromRequest,
+    getSession,
+    createJob,
+    runInBackground,
+    intakeFromGitHub,
+    session: sessionOverrides,
+    jobs: jobsOverrides,
+    collect: collectOverrides,
+  } = overrides;
+
+  const jobs = {
     createJob: vi.fn().mockReturnValue("job_1"),
     runInBackground: vi.fn(),
-    intakeFromGitHub: vi.fn().mockResolvedValue({ contributions: [] }),
-    ...overrides,
+    ...(createJob ? { createJob } : {}),
+    ...(runInBackground ? { runInBackground } : {}),
+    ...(jobsOverrides || {}),
   };
+
+  const options = {
+    session: {
+      getSessionIdFromRequest: () => null,
+      getSession: () => undefined,
+      ...(getSessionIdFromRequest !== undefined ? { getSessionIdFromRequest } : {}),
+      ...(getSession !== undefined ? { getSession } : {}),
+      ...(sessionOverrides || {}),
+    },
+    jobs,
+    collect: {
+      intakeFromGitHub: vi.fn().mockResolvedValue({ contributions: [] }),
+      ...(intakeFromGitHub ? { intakeFromGitHub } : {}),
+      ...(collectOverrides || {}),
+    },
+  };
+
+  options.createJob = jobs.createJob;
+  options.runInBackground = jobs.runInBackground;
+  options.intakeFromGitHub = options.collect.intakeFromGitHub;
+
+  return options;
 }
 
 describe("collectRoutes – POST /", () => {
@@ -84,7 +116,6 @@ describe("collectRoutes – POST /", () => {
 
   it("returns 500 on unexpected errors", async () => {
     const handler = collectRoutes(makeOptions());
-    // Send invalid JSON to trigger parse error
     const badReq = {
       method: "POST",
       url: "/",

--- a/test/routes-jobs.test.js
+++ b/test/routes-jobs.test.js
@@ -3,11 +3,18 @@ import { jobsRoutes } from "../server/routes/jobs.ts";
 import { mockRes } from "./helpers.js";
 
 function makeOptions(overrides = {}) {
-  return {
-    getSessionIdFromRequest: () => null,
+  const jobs = {
     getLatestJob: vi.fn().mockReturnValue(null),
     getJob: vi.fn().mockReturnValue(undefined),
-    ...overrides,
+    ...(overrides.jobs || {}),
+  };
+  return {
+    session: {
+      getSessionIdFromRequest: () => null,
+      getSession: () => undefined,
+      ...(overrides.session || {}),
+    },
+    jobs,
   };
 }
 
@@ -24,8 +31,8 @@ describe("jobsRoutes – GET / (latest)", () => {
   it("returns latest job when session has one", () => {
     const latestJob = { id: "j1", type: "collect", status: "done" };
     const handler = jobsRoutes(makeOptions({
-      getSessionIdFromRequest: () => "sess_1",
-      getLatestJob: vi.fn().mockReturnValue(latestJob),
+      session: { getSessionIdFromRequest: () => "sess_1" },
+      jobs: { getLatestJob: vi.fn().mockReturnValue(latestJob) },
     }));
     const req = { method: "GET", url: "/", headers: {} };
     const res = mockRes();
@@ -39,9 +46,9 @@ describe("jobsRoutes – GET /:id", () => {
   it("returns job by id", () => {
     const job = { type: "collect", status: "done", result: { ok: true } };
     const handler = jobsRoutes(makeOptions({
-      getJob: vi.fn().mockReturnValue(job),
+      jobs: { getJob: vi.fn().mockReturnValue(job) },
     }));
-    const req = { method: "GET", url: "/job_abc", headers: {} };
+    const req = { method: "GET", url: "/j1", headers: {} };
     const res = mockRes();
     handler(req, res, () => {});
     expect(res.statusCode).toBe(200);
@@ -50,25 +57,25 @@ describe("jobsRoutes – GET /:id", () => {
 
   it("returns 404 when job not found", () => {
     const handler = jobsRoutes(makeOptions());
-    const req = { method: "GET", url: "/nonexistent", headers: {} };
+    const req = { method: "GET", url: "/missing", headers: {} };
     const res = mockRes();
     handler(req, res, () => {});
     expect(res.statusCode).toBe(404);
-    expect(res.body.error).toBe("Job not found");
+    expect(res.body.error).toMatch(/not found/i);
   });
 
   it("decodes URL-encoded job id", () => {
     const getJob = vi.fn().mockReturnValue({ type: "collect", status: "done" });
-    const handler = jobsRoutes(makeOptions({ getJob }));
-    const req = { method: "GET", url: "/job%20with%20space", headers: {} };
+    const handler = jobsRoutes(makeOptions({ jobs: { getJob } }));
+    const req = { method: "GET", url: "/job%2Fwith%2Fslashes", headers: {} };
     const res = mockRes();
     handler(req, res, () => {});
-    expect(getJob).toHaveBeenCalledWith("job with space");
+    expect(getJob).toHaveBeenCalledWith("job/with/slashes");
   });
 });
 
-describe("jobsRoutes – non-GET", () => {
-  it("calls next for POST requests", () => {
+describe("jobsRoutes – next()", () => {
+  it("calls next for non-GET requests", () => {
     const handler = jobsRoutes(makeOptions());
     const req = { method: "POST", url: "/", headers: {} };
     const res = mockRes();

--- a/test/routes-periodic.test.js
+++ b/test/routes-periodic.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { periodicRoutes } from "../server/routes/periodic.ts";
-import { mockRes, mockReq, respondJson } from "./helpers.js";
+import { mockRes, mockReq } from "./helpers.js";
 
 const SAMPLE_EVIDENCE = {
   timeframe: { start_date: "2025-01-15", end_date: "2025-01-15" },
@@ -18,13 +18,15 @@ const SAMPLE_DAILY_JSON = JSON.stringify({
 });
 
 const SESSION = { login: "alice", access_token: "gh_tok", created_at: "2025-01-01T00:00:00Z" };
+const LOGGED_IN = {
+  session: {
+    getSessionIdFromRequest: () => "sess1",
+    getSession: () => SESSION,
+  },
+};
 
-function makeOptions(overrides = {}) {
+function defaultPeriodic() {
   return {
-    readJsonBody: vi.fn().mockResolvedValue({}),
-    respondJson,
-    getSessionIdFromRequest: () => null,
-    getSession: () => undefined,
     intakeFromGitHub: vi.fn().mockResolvedValue(SAMPLE_EVIDENCE),
     runDailySummary: vi.fn().mockResolvedValue(SAMPLE_DAILY_JSON),
     runWeeklyRollup: vi.fn().mockResolvedValue(JSON.stringify({
@@ -55,8 +57,21 @@ function makeOptions(overrides = {}) {
     getWeeklySummariesForMonth: vi.fn().mockResolvedValue([]),
     deletePeriodicSummary: vi.fn().mockResolvedValue(false),
     isPeriodicStoreConfigured: () => true,
-    ...overrides,
   };
+}
+
+function makeOptions(overrides = {}) {
+  const periodic = { ...defaultPeriodic(), ...(overrides.periodic || {}) };
+  const options = {
+    session: {
+      getSessionIdFromRequest: () => null,
+      getSession: () => undefined,
+      ...(overrides.session || {}),
+    },
+    periodic,
+  };
+  Object.assign(options, periodic);
+  return options;
 }
 
 // ── Auth ─────────────────────────────────────────────────────────────────────
@@ -100,9 +115,8 @@ describe("periodicRoutes – auth", () => {
 describe("periodicRoutes – not configured", () => {
   it("returns 503 when store not configured", async () => {
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      isPeriodicStoreConfigured: () => false,
+      ...LOGGED_IN,
+      periodic: { isPeriodicStoreConfigured: () => false },
     });
     const handler = periodicRoutes(opts);
     const req = mockReq("GET", "/summaries");
@@ -118,12 +132,13 @@ describe("periodicRoutes – not configured", () => {
 describe("periodicRoutes – POST /collect-day", () => {
   it("returns 401 when no GitHub token is available", async () => {
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => ({ login: "alice", created_at: "2025-01-01T00:00:00Z" }), // no access_token
-      readJsonBody: vi.fn().mockResolvedValue({}),
+      session: {
+        getSessionIdFromRequest: () => "sess1",
+        getSession: () => ({ login: "alice", created_at: "2025-01-01T00:00:00Z" }),
+      },
     });
     const handler = periodicRoutes(opts);
-    const req = mockReq("POST", "/collect-day");
+    const req = mockReq("POST", "/collect-day", {});
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(401);
@@ -131,13 +146,8 @@ describe("periodicRoutes – POST /collect-day", () => {
   });
 
   it("returns 400 for invalid date format", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({ date: "15/01/2025" }),
-    });
-    const handler = periodicRoutes(opts);
-    const req = mockReq("POST", "/collect-day");
+    const handler = periodicRoutes(makeOptions(LOGGED_IN));
+    const req = mockReq("POST", "/collect-day", { date: "15/01/2025" });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(400);
@@ -150,15 +160,15 @@ describe("periodicRoutes – POST /collect-day", () => {
     const mockSave = vi.fn().mockResolvedValue("pday_new");
 
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({ date: "2025-01-15" }),
-      intakeFromGitHub: mockCollect,
-      runDailySummary: mockSummary,
-      saveDailySummary: mockSave,
+      ...LOGGED_IN,
+      periodic: {
+        intakeFromGitHub: mockCollect,
+        runDailySummary: mockSummary,
+        saveDailySummary: mockSave,
+      },
     });
     const handler = periodicRoutes(opts);
-    const req = mockReq("POST", "/collect-day");
+    const req = mockReq("POST", "/collect-day", { date: "2025-01-15" });
     const res = mockRes();
     await handler(req, res, () => {});
 
@@ -177,13 +187,11 @@ describe("periodicRoutes – POST /collect-day", () => {
   it("uses session token when no token in body", async () => {
     const mockCollect = vi.fn().mockResolvedValue(SAMPLE_EVIDENCE);
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION, // has access_token: "gh_tok"
-      readJsonBody: vi.fn().mockResolvedValue({ date: "2025-01-15" }),
-      intakeFromGitHub: mockCollect,
+      ...LOGGED_IN,
+      periodic: { intakeFromGitHub: mockCollect },
     });
     const handler = periodicRoutes(opts);
-    const req = mockReq("POST", "/collect-day");
+    const req = mockReq("POST", "/collect-day", { date: "2025-01-15" });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(mockCollect).toHaveBeenCalledWith(
@@ -196,14 +204,11 @@ describe("periodicRoutes – POST /collect-day", () => {
 
 describe("periodicRoutes – POST /rollup-week", () => {
   it("returns 404 when no daily summaries found for the week", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({ week_start: "2025-01-13" }),
-      getDailySummariesForWeek: vi.fn().mockResolvedValue([]),
-    });
-    const handler = periodicRoutes(opts);
-    const req = mockReq("POST", "/rollup-week");
+    const handler = periodicRoutes(makeOptions({
+      ...LOGGED_IN,
+      periodic: { getDailySummariesForWeek: vi.fn().mockResolvedValue([]) },
+    }));
+    const req = mockReq("POST", "/rollup-week", { week_start: "2025-01-13" });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(404);
@@ -234,15 +239,15 @@ describe("periodicRoutes – POST /rollup-week", () => {
     }));
     const mockSave = vi.fn().mockResolvedValue("pwk_new");
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({ week_start: "2025-01-13" }),
-      getDailySummariesForWeek: vi.fn().mockResolvedValue([daily]),
-      runWeeklyRollup: mockRollup,
-      saveWeeklyRollup: mockSave,
+      ...LOGGED_IN,
+      periodic: {
+        getDailySummariesForWeek: vi.fn().mockResolvedValue([daily]),
+        runWeeklyRollup: mockRollup,
+        saveWeeklyRollup: mockSave,
+      },
     });
     const handler = periodicRoutes(opts);
-    const req = mockReq("POST", "/rollup-week");
+    const req = mockReq("POST", "/rollup-week", { week_start: "2025-01-13" });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(201);
@@ -257,13 +262,8 @@ describe("periodicRoutes – POST /rollup-week", () => {
 
 describe("periodicRoutes – POST /rollup-month", () => {
   it("returns 400 for invalid month format", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({ month: "January 2025" }),
-    });
-    const handler = periodicRoutes(opts);
-    const req = mockReq("POST", "/rollup-month");
+    const handler = periodicRoutes(makeOptions(LOGGED_IN));
+    const req = mockReq("POST", "/rollup-month", { month: "January 2025" });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(400);
@@ -271,14 +271,11 @@ describe("periodicRoutes – POST /rollup-month", () => {
   });
 
   it("returns 404 when no weekly summaries for month", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({ month: "2025-01" }),
-      getWeeklySummariesForMonth: vi.fn().mockResolvedValue([]),
-    });
-    const handler = periodicRoutes(opts);
-    const req = mockReq("POST", "/rollup-month");
+    const handler = periodicRoutes(makeOptions({
+      ...LOGGED_IN,
+      periodic: { getWeeklySummariesForMonth: vi.fn().mockResolvedValue([]) },
+    }));
+    const req = mockReq("POST", "/rollup-month", { month: "2025-01" });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(404);
@@ -300,14 +297,14 @@ describe("periodicRoutes – POST /rollup-month", () => {
     };
     const mockSave = vi.fn().mockResolvedValue("pmo_new");
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({ month: "2025-01" }),
-      getWeeklySummariesForMonth: vi.fn().mockResolvedValue([weekly]),
-      saveMonthlyRollup: mockSave,
+      ...LOGGED_IN,
+      periodic: {
+        getWeeklySummariesForMonth: vi.fn().mockResolvedValue([weekly]),
+        saveMonthlyRollup: mockSave,
+      },
     });
     const handler = periodicRoutes(opts);
-    const req = mockReq("POST", "/rollup-month");
+    const req = mockReq("POST", "/rollup-month", { month: "2025-01" });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(201);
@@ -322,11 +319,7 @@ describe("periodicRoutes – POST /rollup-month", () => {
 
 describe("periodicRoutes – GET /summaries", () => {
   it("returns empty list when no summaries", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-    });
-    const handler = periodicRoutes(opts);
+    const handler = periodicRoutes(makeOptions(LOGGED_IN));
     const req = mockReq("GET", "/summaries");
     const res = mockRes();
     await handler(req, res, () => {});
@@ -337,9 +330,8 @@ describe("periodicRoutes – GET /summaries", () => {
   it("passes type filter to store", async () => {
     const mockList = vi.fn().mockResolvedValue([]);
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      listPeriodicSummaries: mockList,
+      ...LOGGED_IN,
+      periodic: { listPeriodicSummaries: mockList },
     });
     const handler = periodicRoutes(opts);
     const req = mockReq("GET", "/summaries?type=daily");
@@ -363,9 +355,8 @@ describe("periodicRoutes – GET /summaries", () => {
       created_at: "2025-01-15T23:00:00Z",
     }]);
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      listPeriodicSummaries: mockList,
+      ...LOGGED_IN,
+      periodic: { listPeriodicSummaries: mockList },
     });
     const handler = periodicRoutes(opts);
     const req = mockReq("GET", "/summaries");
@@ -383,9 +374,8 @@ describe("periodicRoutes – GET /summaries", () => {
 describe("periodicRoutes – GET /summary/:id", () => {
   it("returns 404 when not found", async () => {
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      getPeriodicSummary: vi.fn().mockResolvedValue(null),
+      ...LOGGED_IN,
+      periodic: { getPeriodicSummary: vi.fn().mockResolvedValue(null) },
     });
     const handler = periodicRoutes(opts);
     const req = mockReq("GET", "/summary/missing");
@@ -409,9 +399,8 @@ describe("periodicRoutes – GET /summary/:id", () => {
       created_at: "2025-01-15T23:00:00Z",
     };
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      getPeriodicSummary: vi.fn().mockResolvedValue(snap),
+      ...LOGGED_IN,
+      periodic: { getPeriodicSummary: vi.fn().mockResolvedValue(snap) },
     });
     const handler = periodicRoutes(opts);
     const req = mockReq("GET", "/summary/pday_1");
@@ -428,9 +417,8 @@ describe("periodicRoutes – GET /summary/:id", () => {
 describe("periodicRoutes – DELETE /summary/:id", () => {
   it("returns 404 when not found", async () => {
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      deletePeriodicSummary: vi.fn().mockResolvedValue(false),
+      ...LOGGED_IN,
+      periodic: { deletePeriodicSummary: vi.fn().mockResolvedValue(false) },
     });
     const handler = periodicRoutes(opts);
     const req = mockReq("DELETE", "/summary/missing");
@@ -441,9 +429,8 @@ describe("periodicRoutes – DELETE /summary/:id", () => {
 
   it("returns 200 when deleted", async () => {
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      deletePeriodicSummary: vi.fn().mockResolvedValue(true),
+      ...LOGGED_IN,
+      periodic: { deletePeriodicSummary: vi.fn().mockResolvedValue(true) },
     });
     const handler = periodicRoutes(opts);
     const req = mockReq("DELETE", "/summary/pday_1");
@@ -458,11 +445,7 @@ describe("periodicRoutes – DELETE /summary/:id", () => {
 
 describe("periodicRoutes – next()", () => {
   it("calls next for unmatched routes", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-    });
-    const handler = periodicRoutes(opts);
+    const handler = periodicRoutes(makeOptions(LOGGED_IN));
     const req = mockReq("PUT", "/unknown");
     const res = mockRes();
     let nextCalled = false;

--- a/test/routes-snapshots.test.js
+++ b/test/routes-snapshots.test.js
@@ -1,29 +1,41 @@
 import { describe, it, expect, vi } from "vitest";
 import { snapshotsRoutes } from "../server/routes/snapshots.ts";
-import { mockRes, mockReq, respondJson } from "./helpers.js";
+import { mockRes, mockReq } from "./helpers.js";
 
 const SAMPLE_EVIDENCE = {
   timeframe: { start_date: "2025-01-01", end_date: "2025-01-07" },
   contributions: [{ id: "repo#1", type: "pull_request", title: "Fix bug", url: "https://github.com/org/repo/pull/1", repo: "org/repo" }],
 };
 
+const SESSION = { login: "user1", access_token: "tok", created_at: "2025-01-01T00:00:00Z" };
+const LOGGED_IN = {
+  session: {
+    getSessionIdFromRequest: () => "sess1",
+    getSession: () => SESSION,
+  },
+};
+
 function makeOptions(overrides = {}) {
-  return {
-    readJsonBody: vi.fn().mockResolvedValue({}),
-    respondJson,
-    getSessionIdFromRequest: () => null,
-    getSession: () => undefined,
+  const snapshots = {
     saveSnapshot: vi.fn().mockResolvedValue("snap_abc"),
     listSnapshots: vi.fn().mockResolvedValue([]),
     getSnapshot: vi.fn().mockResolvedValue(null),
     deleteSnapshot: vi.fn().mockResolvedValue(false),
     mergeSnapshots: vi.fn().mockResolvedValue(null),
     isSnapshotStoreConfigured: () => true,
-    ...overrides,
+    ...(overrides.snapshots || {}),
   };
+  const options = {
+    session: {
+      getSessionIdFromRequest: () => null,
+      getSession: () => undefined,
+      ...(overrides.session || {}),
+    },
+    snapshots,
+  };
+  Object.assign(options, snapshots);
+  return options;
 }
-
-const SESSION = { login: "user1", access_token: "tok", created_at: "2025-01-01T00:00:00Z" };
 
 describe("snapshotsRoutes – auth", () => {
   it("returns 401 when not logged in for GET /", async () => {
@@ -36,9 +48,7 @@ describe("snapshotsRoutes – auth", () => {
   });
 
   it("returns 401 when not logged in for POST /", async () => {
-    const handler = snapshotsRoutes(makeOptions({
-      readJsonBody: vi.fn().mockResolvedValue({}),
-    }));
+    const handler = snapshotsRoutes(makeOptions());
     const req = mockReq("POST", "/");
     const res = mockRes();
     await handler(req, res, () => {});
@@ -49,9 +59,8 @@ describe("snapshotsRoutes – auth", () => {
 describe("snapshotsRoutes – GET /", () => {
   it("returns empty snapshots list for logged-in user", async () => {
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      listSnapshots: vi.fn().mockResolvedValue([]),
+      ...LOGGED_IN,
+      snapshots: { listSnapshots: vi.fn().mockResolvedValue([]) },
     });
     const handler = snapshotsRoutes(opts);
     const req = mockReq("GET", "/");
@@ -73,9 +82,8 @@ describe("snapshotsRoutes – GET /", () => {
       created_at: "2025-01-08T00:00:00Z",
     };
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      listSnapshots: vi.fn().mockResolvedValue([snap]),
+      ...LOGGED_IN,
+      snapshots: { listSnapshots: vi.fn().mockResolvedValue([snap]) },
     });
     const handler = snapshotsRoutes(opts);
     const req = mockReq("GET", "/");
@@ -89,17 +97,12 @@ describe("snapshotsRoutes – GET /", () => {
 
 describe("snapshotsRoutes – POST /", () => {
   it("returns 400 when period is missing", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({
-        start_date: "2025-01-01",
-        end_date: "2025-01-07",
-        evidence: SAMPLE_EVIDENCE,
-      }),
+    const handler = snapshotsRoutes(makeOptions(LOGGED_IN));
+    const req = mockReq("POST", "/", {
+      start_date: "2025-01-01",
+      end_date: "2025-01-07",
+      evidence: SAMPLE_EVIDENCE,
     });
-    const handler = snapshotsRoutes(opts);
-    const req = mockReq("POST", "/");
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(400);
@@ -107,18 +110,13 @@ describe("snapshotsRoutes – POST /", () => {
   });
 
   it("returns 400 when start_date is invalid", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({
-        period: "weekly",
-        start_date: "not-a-date",
-        end_date: "2025-01-07",
-        evidence: SAMPLE_EVIDENCE,
-      }),
+    const handler = snapshotsRoutes(makeOptions(LOGGED_IN));
+    const req = mockReq("POST", "/", {
+      period: "weekly",
+      start_date: "not-a-date",
+      end_date: "2025-01-07",
+      evidence: SAMPLE_EVIDENCE,
     });
-    const handler = snapshotsRoutes(opts);
-    const req = mockReq("POST", "/");
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(400);
@@ -127,19 +125,17 @@ describe("snapshotsRoutes – POST /", () => {
 
   it("returns 201 with id on valid save", async () => {
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({
-        period: "weekly",
-        start_date: "2025-01-01",
-        end_date: "2025-01-07",
-        evidence: SAMPLE_EVIDENCE,
-        label: "Week 1",
-      }),
-      saveSnapshot: vi.fn().mockResolvedValue("snap_new"),
+      ...LOGGED_IN,
+      snapshots: { saveSnapshot: vi.fn().mockResolvedValue("snap_new") },
     });
     const handler = snapshotsRoutes(opts);
-    const req = mockReq("POST", "/");
+    const req = mockReq("POST", "/", {
+      period: "weekly",
+      start_date: "2025-01-01",
+      end_date: "2025-01-07",
+      evidence: SAMPLE_EVIDENCE,
+      label: "Week 1",
+    });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(201);
@@ -155,17 +151,12 @@ describe("snapshotsRoutes – POST /", () => {
   });
 
   it("returns 400 when evidence is missing", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({
-        period: "weekly",
-        start_date: "2025-01-01",
-        end_date: "2025-01-07",
-      }),
+    const handler = snapshotsRoutes(makeOptions(LOGGED_IN));
+    const req = mockReq("POST", "/", {
+      period: "weekly",
+      start_date: "2025-01-01",
+      end_date: "2025-01-07",
     });
-    const handler = snapshotsRoutes(opts);
-    const req = mockReq("POST", "/");
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(400);
@@ -175,12 +166,7 @@ describe("snapshotsRoutes – POST /", () => {
 
 describe("snapshotsRoutes – GET /:id", () => {
   it("returns 404 when snapshot not found", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      getSnapshot: vi.fn().mockResolvedValue(null),
-    });
-    const handler = snapshotsRoutes(opts);
+    const handler = snapshotsRoutes(makeOptions(LOGGED_IN));
     const req = mockReq("GET", "/snap_missing");
     const res = mockRes();
     await handler(req, res, () => {});
@@ -199,12 +185,10 @@ describe("snapshotsRoutes – GET /:id", () => {
       evidence: SAMPLE_EVIDENCE,
       created_at: "2025-01-08T00:00:00Z",
     };
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      getSnapshot: vi.fn().mockResolvedValue(snap),
-    });
-    const handler = snapshotsRoutes(opts);
+    const handler = snapshotsRoutes(makeOptions({
+      ...LOGGED_IN,
+      snapshots: { getSnapshot: vi.fn().mockResolvedValue(snap) },
+    }));
     const req = mockReq("GET", "/snap_1");
     const res = mockRes();
     await handler(req, res, () => {});
@@ -215,12 +199,7 @@ describe("snapshotsRoutes – GET /:id", () => {
 
 describe("snapshotsRoutes – DELETE /:id", () => {
   it("returns 404 when snapshot not found", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      deleteSnapshot: vi.fn().mockResolvedValue(false),
-    });
-    const handler = snapshotsRoutes(opts);
+    const handler = snapshotsRoutes(makeOptions(LOGGED_IN));
     const req = mockReq("DELETE", "/snap_missing");
     const res = mockRes();
     await handler(req, res, () => {});
@@ -229,9 +208,8 @@ describe("snapshotsRoutes – DELETE /:id", () => {
 
   it("returns 200 when snapshot is deleted", async () => {
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      deleteSnapshot: vi.fn().mockResolvedValue(true),
+      ...LOGGED_IN,
+      snapshots: { deleteSnapshot: vi.fn().mockResolvedValue(true) },
     });
     const handler = snapshotsRoutes(opts);
     const req = mockReq("DELETE", "/snap_1");
@@ -245,13 +223,8 @@ describe("snapshotsRoutes – DELETE /:id", () => {
 
 describe("snapshotsRoutes – POST /merge", () => {
   it("returns 400 when ids is missing", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({}),
-    });
-    const handler = snapshotsRoutes(opts);
-    const req = mockReq("POST", "/merge");
+    const handler = snapshotsRoutes(makeOptions(LOGGED_IN));
+    const req = mockReq("POST", "/merge", {});
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(400);
@@ -259,27 +232,19 @@ describe("snapshotsRoutes – POST /merge", () => {
   });
 
   it("returns 400 when ids is empty array", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({ ids: [] }),
-    });
-    const handler = snapshotsRoutes(opts);
-    const req = mockReq("POST", "/merge");
+    const handler = snapshotsRoutes(makeOptions(LOGGED_IN));
+    const req = mockReq("POST", "/merge", { ids: [] });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(400);
   });
 
   it("returns 404 when no snapshots found", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({ ids: ["snap_1", "snap_2"] }),
-      mergeSnapshots: vi.fn().mockResolvedValue(null),
-    });
-    const handler = snapshotsRoutes(opts);
-    const req = mockReq("POST", "/merge");
+    const handler = snapshotsRoutes(makeOptions({
+      ...LOGGED_IN,
+      snapshots: { mergeSnapshots: vi.fn().mockResolvedValue(null) },
+    }));
+    const req = mockReq("POST", "/merge", { ids: ["snap_1", "snap_2"] });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(404);
@@ -294,13 +259,11 @@ describe("snapshotsRoutes – POST /merge", () => {
       ],
     };
     const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      readJsonBody: vi.fn().mockResolvedValue({ ids: ["snap_1", "snap_2"] }),
-      mergeSnapshots: vi.fn().mockResolvedValue(merged),
+      ...LOGGED_IN,
+      snapshots: { mergeSnapshots: vi.fn().mockResolvedValue(merged) },
     });
     const handler = snapshotsRoutes(opts);
-    const req = mockReq("POST", "/merge");
+    const req = mockReq("POST", "/merge", { ids: ["snap_1", "snap_2"] });
     const res = mockRes();
     await handler(req, res, () => {});
     expect(res.statusCode).toBe(200);
@@ -312,12 +275,10 @@ describe("snapshotsRoutes – POST /merge", () => {
 
 describe("snapshotsRoutes – not configured", () => {
   it("returns 503 when snapshot store not configured", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-      isSnapshotStoreConfigured: () => false,
-    });
-    const handler = snapshotsRoutes(opts);
+    const handler = snapshotsRoutes(makeOptions({
+      ...LOGGED_IN,
+      snapshots: { isSnapshotStoreConfigured: () => false },
+    }));
     const req = mockReq("GET", "/");
     const res = mockRes();
     await handler(req, res, () => {});
@@ -328,11 +289,7 @@ describe("snapshotsRoutes – not configured", () => {
 
 describe("snapshotsRoutes – next()", () => {
   it("calls next() for unmatched routes", async () => {
-    const opts = makeOptions({
-      getSessionIdFromRequest: () => "sess1",
-      getSession: () => SESSION,
-    });
-    const handler = snapshotsRoutes(opts);
+    const handler = snapshotsRoutes(makeOptions(LOGGED_IN));
     const req = mockReq("PUT", "/unknown");
     const res = mockRes();
     let nextCalled = false;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -84,6 +84,8 @@ function apiRoutesPlugin() {
         env.GITHUB_CLIENT_SECRET || process.env.GITHUB_CLIENT_SECRET;
       const getSessionId = (r: { headers?: { cookie?: string } }) =>
         getSessionIdFromRequest(r, sessionSecret);
+      const session = { getSessionIdFromRequest: getSessionId, getSession };
+      const jobs = { createJob, runInBackground };
 
       function getRequestContext(req: { headers: Record<string, string | string[] | undefined> }) {
         const isSecure = req.headers["x-forwarded-proto"] === "https";
@@ -133,57 +135,41 @@ function apiRoutesPlugin() {
       server.middlewares.use(
         "/api/jobs",
         jobsRoutes({
-          getSessionIdFromRequest: getSessionId,
-          getLatestJob,
-          getJob,
+          session,
+          jobs: { getLatestJob, getJob },
         })
       );
 
       server.middlewares.use(
         "/api/generate",
         generateRoutes({
-          validateEvidence,
-          createJob,
-          runInBackground,
-          runPipeline,
-          getSessionIdFromRequest: getSessionId,
-          getSession,
+          session,
+          jobs,
+          pipeline: { validateEvidence, runPipeline },
         })
       );
 
       server.middlewares.use(
         "/api/collect",
         collectRoutes({
-          getSessionIdFromRequest: getSessionId,
-          getSession,
-          createJob,
-          runInBackground,
-          intakeFromGitHub,
+          session,
+          jobs,
+          collect: { intakeFromGitHub },
         })
       );
 
       server.middlewares.use(
         "/api/payments",
-        paymentsRoutes({
-          getSessionIdFromRequest: getSessionId,
-          getSession,
-        })
+        paymentsRoutes({ session })
       );
       server.middlewares.use(
         "/api/snapshots",
-        snapshotsRoutes({
-          getSessionIdFromRequest: getSessionId,
-          getSession,
-        })
+        snapshotsRoutes({ session })
       );
 
       server.middlewares.use(
         "/api/periodic",
-        periodicRoutes({
-          getSessionIdFromRequest: getSessionId,
-          getSession,
-          intakeFromGitHub,
-        })
+        periodicRoutes({ session })
       );
     },
   };


### PR DESCRIPTION
## Summary
- Replace per-route mega-options bags with composed service objects (`SessionService`, `JobRunnerService`, and route-family deps like `SnapshotService`, `PeriodicService`, `GeneratePipelineService`).
- Import `server/helpers.ts` utilities directly instead of injecting them into route options.
- Simplify `server.ts` and `vite.config.ts` wiring to a small composition root over the recent `lib/` seams (evidence intake, evidence archive adapters, narrative runner).

## Test plan
- [x] `yarn test` (451 passed)
- [x] `yarn typecheck`

Closes #128

Made with [Cursor](https://cursor.com)